### PR TITLE
add hdf-vol-plugin based on the db-interface of JULEA

### DIFF
--- a/lib/hdf5-db/jhdf5-db-attr.c
+++ b/lib/hdf5-db/jhdf5-db-attr.c
@@ -1,0 +1,574 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#ifndef JULEA_DB_HDF5_ATTR_C
+#define JULEA_DB_HDF5_ATTR_C
+
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "jhdf5-db.h"
+#include "jhdf5-db-shared.c"
+#include "jhdf5-db-datatype.c"
+#include "jhdf5-db-space.c"
+#include "jhdf5-db-link.c"
+
+#define _GNU_SOURCE
+
+static
+JDBSchema* julea_db_schema_attr = NULL;
+
+static
+herr_t
+H5VL_julea_db_attr_term(void)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (julea_db_schema_attr)
+	{
+		j_db_schema_unref(julea_db_schema_attr);
+	}
+	julea_db_schema_attr = NULL;
+	return 0;
+}
+static
+herr_t
+H5VL_julea_db_attr_init(hid_t vipl_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(julea_db_schema_attr = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "attr", NULL)))
+	{
+		j_goto_error();
+	}
+	if (!(j_db_schema_get(julea_db_schema_attr, batch, &error) && j_batch_execute(batch)))
+	{
+		if (error)
+		{
+			if (error->code == J_BACKEND_DB_ERROR_SCHEMA_NOT_FOUND)
+			{
+				g_error_free(error);
+				error = NULL;
+				if (julea_db_schema_attr)
+				{
+					j_db_schema_unref(julea_db_schema_attr);
+				}
+				if (!(julea_db_schema_attr = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "attr", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_attr, "file", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_attr, "datatype", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_attr, "space", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				{
+					const gchar* index[] = {
+						"file",
+						NULL,
+					};
+					if (!j_db_schema_add_index(julea_db_schema_attr, index, &error))
+					{
+						j_goto_error();
+					}
+				}
+				if (!j_db_schema_create(julea_db_schema_attr, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+				if (julea_db_schema_attr)
+				{
+					j_db_schema_unref(julea_db_schema_attr);
+				}
+				if (!(julea_db_schema_attr = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "attr", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_get(julea_db_schema_attr, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+			}
+			else
+			{
+				g_assert_not_reached();
+				j_goto_error();
+			}
+		}
+		else
+		{
+			g_assert_not_reached();
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return 1;
+}
+static
+herr_t
+H5VL_julea_db_attr_truncate_file(void* obj)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	JHDF5Object_t* file = obj;
+
+	g_return_val_if_fail(file != NULL, 1);
+	g_return_val_if_fail(file->type == J_HDF5_OBJECT_TYPE_FILE, 1);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_attr, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "file", J_DB_SELECTOR_OPERATOR_EQ, file->backend_id, file->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_attr, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_delete(entry, selector, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		if (!error || error->code != J_BACKEND_DB_ERROR_ITERATOR_NO_MORE_ELEMENTS)
+		{
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return 1;
+}
+static
+void*
+H5VL_julea_db_attr_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name,
+	hid_t type_id, hid_t space_id, hid_t acpl_id, hid_t aapl_id,
+	hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autofree char* hex_buf = NULL;
+	JHDF5Object_t* object = NULL;
+	JHDF5Object_t* parent = obj;
+	JHDF5Object_t* file;
+
+	g_return_val_if_fail(name != NULL, NULL);
+	g_return_val_if_fail(parent != NULL, NULL);
+
+	switch (parent->type)
+	{
+	case J_HDF5_OBJECT_TYPE_FILE:
+		file = parent;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		file = parent->dataset.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		file = parent->attr.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		file = parent->group.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_ATTR)))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.name = g_strdup(name)))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.file = H5VL_julea_db_object_ref(file)))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.datatype = H5VL_julea_db_datatype_encode(&type_id)))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.space = H5VL_julea_db_space_encode(&space_id)))
+	{
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_attr, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "file", file->backend_id, file->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "datatype", object->attr.datatype->backend_id, object->attr.datatype->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "space", object->attr.space->backend_id, object->attr.space->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_insert(entry, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_get_id(entry, &object->backend_id, &object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.distribution = j_distribution_new(J_DISTRIBUTION_ROUND_ROBIN)))
+	{
+		j_goto_error();
+	}
+	if (!(hex_buf = H5VL_julea_db_buf_to_hex("attr", object->backend_id, object->backend_id_len)))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.object = j_distributed_object_new(JULEA_HDF5_DB_NAMESPACE, hex_buf, object->attr.distribution)))
+	{
+		j_goto_error();
+	}
+	j_distributed_object_create(object->attr.object, batch);
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	if (!H5VL_julea_db_link_create_helper(parent, object, name))
+	{
+		j_goto_error();
+	}
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+static
+void*
+H5VL_julea_db_attr_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name,
+	hid_t aapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autofree char* hex_buf = NULL;
+	g_autofree void* space_id_buf = NULL;
+	g_autofree void* datatype_id_buf = NULL;
+	JHDF5Object_t* object = NULL;
+	JHDF5Object_t* parent = obj;
+	JHDF5Object_t* file;
+	JDBType type;
+	guint64 space_id_buf_len;
+	guint64 datatype_id_buf_len;
+
+	g_return_val_if_fail(name != NULL, NULL);
+	g_return_val_if_fail(parent != NULL, NULL);
+
+	switch (parent->type)
+	{
+	case J_HDF5_OBJECT_TYPE_FILE:
+		file = parent;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		file = parent->dataset.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		file = parent->attr.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		file = parent->group.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_ATTR)))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.name = g_strdup(name)))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.file = H5VL_julea_db_object_ref(file)))
+	{
+		j_goto_error();
+	}
+	if (!H5VL_julea_db_link_get_helper(parent, object, name))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_attr, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "_id", J_DB_SELECTOR_OPERATOR_EQ, object->backend_id, object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_attr, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_next(iterator, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "space", &type, &space_id_buf, &space_id_buf_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.space = H5VL_julea_db_space_decode(space_id_buf, space_id_buf_len)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "datatype", &type, &datatype_id_buf, &datatype_id_buf_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.datatype = H5VL_julea_db_datatype_decode(datatype_id_buf, datatype_id_buf_len)))
+	{
+		j_goto_error();
+	}
+	g_assert(!j_db_iterator_next(iterator, NULL));
+	if (!(object->attr.distribution = j_distribution_new(J_DISTRIBUTION_ROUND_ROBIN)))
+	{
+		j_goto_error();
+	}
+	if (!(hex_buf = H5VL_julea_db_buf_to_hex("attr", object->backend_id, object->backend_id_len)))
+	{
+		j_goto_error();
+	}
+	if (!(object->attr.object = j_distributed_object_new(JULEA_HDF5_DB_NAMESPACE, hex_buf, object->attr.distribution)))
+	{
+		j_goto_error();
+	}
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+static
+herr_t
+H5VL_julea_db_attr_read(void* obj, hid_t mem_type_id, void* buf, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	guint64 bytes_read;
+	gsize data_size;
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(buf != NULL, 1);
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_ATTR, 1);
+
+	batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT);
+	bytes_read = 0;
+	data_size = object->dataset.datatype->datatype.type_total_size;
+	data_size *= object->attr.space->space.dim_total_count;
+	j_distributed_object_read(object->attr.object, buf, data_size, 0, &bytes_read, batch);
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	return 0;
+_error:
+	return 1;
+}
+static
+herr_t
+H5VL_julea_db_attr_write(void* obj, hid_t mem_type_id, const void* buf, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	guint64 bytes_written;
+	gsize data_size;
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(buf != NULL, 1);
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_ATTR, 1);
+
+	batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT);
+	bytes_written = 0;
+	data_size = object->dataset.datatype->datatype.type_total_size;
+	data_size *= object->attr.space->space.dim_total_count;
+	j_distributed_object_write(object->attr.object, buf, data_size, 0, &bytes_written, batch);
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	return 0;
+_error:
+	return 1;
+}
+static
+herr_t
+H5VL_julea_db_attr_get(void* obj, H5VL_attr_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_ATTR, 1);
+
+	switch (get_type)
+	{
+	case H5VL_ATTR_GET_SPACE:
+		*(va_arg(arguments, hid_t*)) = object->attr.space->space.hdf5_id;
+		break;
+	case H5VL_ATTR_GET_TYPE:
+		*(va_arg(arguments, hid_t*)) = object->attr.datatype->datatype.hdf5_id;
+		break;
+	case H5VL_ATTR_GET_ACPL:
+	case H5VL_ATTR_GET_INFO:
+	case H5VL_ATTR_GET_NAME:
+	case H5VL_ATTR_GET_STORAGE_SIZE:
+	default:
+		g_assert_not_reached();
+		exit(1);
+	}
+	return 0;
+}
+static
+herr_t
+H5VL_julea_db_attr_specific(void* obj, const H5VL_loc_params_t* loc_params, H5VL_attr_specific_t specific_type,
+	hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_ATTR, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_attr_optional(void* obj, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_ATTR, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_attr_close(void* obj, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_ATTR, 1);
+
+	H5VL_julea_db_object_unref(object);
+	return 0;
+}
+#pragma GCC diagnostic pop
+#endif

--- a/lib/hdf5-db/jhdf5-db-attr.c
+++ b/lib/hdf5-db/jhdf5-db-attr.c
@@ -37,10 +37,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "jhdf5-db.h"
 #include "jhdf5-db-shared.c"
 #include "jhdf5-db-datatype.c"
@@ -570,5 +566,4 @@ H5VL_julea_db_attr_close(void* obj, hid_t dxpl_id, void** req)
 	H5VL_julea_db_object_unref(object);
 	return 0;
 }
-#pragma GCC diagnostic pop
 #endif

--- a/lib/hdf5-db/jhdf5-db-dataset.c
+++ b/lib/hdf5-db/jhdf5-db-dataset.c
@@ -36,10 +36,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "jhdf5-db.h"
 #include "jhdf5-db-shared.c"
 #include "jhdf5-db-datatype.c"
@@ -1077,5 +1073,4 @@ _error:
 	H5VL_julea_db_object_unref(object);
 	return 1;
 }
-#pragma GCC diagnostic pop
 #endif

--- a/lib/hdf5-db/jhdf5-db-dataset.c
+++ b/lib/hdf5-db/jhdf5-db-dataset.c
@@ -1,0 +1,1081 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+#ifndef JULEA_DB_HDF5_DATASET_C
+#define JULEA_DB_HDF5_DATASET_C
+
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "jhdf5-db.h"
+#include "jhdf5-db-shared.c"
+#include "jhdf5-db-datatype.c"
+#include "jhdf5-db-space.c"
+#include "jhdf5-db-link.c"
+
+#define _GNU_SOURCE
+
+static
+JDBSchema* julea_db_schema_dataset = NULL;
+
+static
+herr_t
+H5VL_julea_db_dataset_term(void)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (julea_db_schema_dataset)
+	{
+		j_db_schema_unref(julea_db_schema_dataset);
+	}
+	julea_db_schema_dataset = NULL;
+	return 0;
+}
+
+static
+herr_t
+H5VL_julea_db_dataset_init(hid_t vipl_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(julea_db_schema_dataset = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "dataset", NULL)))
+	{
+		j_goto_error();
+	}
+	if (!(j_db_schema_get(julea_db_schema_dataset, batch, &error) && j_batch_execute(batch)))
+	{
+		if (error)
+		{
+			if (error->code == J_BACKEND_DB_ERROR_SCHEMA_NOT_FOUND)
+			{
+				g_error_free(error);
+				error = NULL;
+				if (julea_db_schema_dataset)
+				{
+					j_db_schema_unref(julea_db_schema_dataset);
+				}
+				if (!(julea_db_schema_dataset = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "dataset", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_dataset, "file", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_dataset, "datatype", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_dataset, "space", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_dataset, "min_value_f", J_DB_TYPE_FLOAT64, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_dataset, "max_value_f", J_DB_TYPE_FLOAT64, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_dataset, "min_value_i", J_DB_TYPE_SINT64, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_dataset, "max_value_i", J_DB_TYPE_SINT64, &error))
+				{
+					j_goto_error();
+				}
+				{
+					const gchar* index[] = {
+						"file",
+						NULL,
+					};
+					if (!j_db_schema_add_index(julea_db_schema_dataset, index, &error))
+					{
+						j_goto_error();
+					}
+				}
+				if (!j_db_schema_create(julea_db_schema_dataset, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+				if (julea_db_schema_dataset)
+				{
+					j_db_schema_unref(julea_db_schema_dataset);
+				}
+				if (!(julea_db_schema_dataset = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "dataset", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_get(julea_db_schema_dataset, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+			}
+			else
+			{
+				g_assert_not_reached();
+				j_goto_error();
+			}
+		}
+		else
+		{
+			g_assert_not_reached();
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return 1;
+}
+static
+herr_t
+H5VL_julea_db_dataset_truncate_file(void* obj)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	JHDF5Object_t* file = obj;
+
+	g_return_val_if_fail(file != NULL, 1);
+	g_return_val_if_fail(file->type == J_HDF5_OBJECT_TYPE_FILE, 1);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_dataset, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "file", J_DB_SELECTOR_OPERATOR_EQ, file->backend_id, file->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_dataset, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_delete(entry, selector, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		if (!error || error->code != J_BACKEND_DB_ERROR_ITERATOR_NO_MORE_ELEMENTS)
+		{
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return 1;
+}
+static
+void*
+H5VL_julea_db_dataset_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name,
+	hid_t lcpl_id, hid_t type_id, hid_t space_id, hid_t dcpl_id,
+	hid_t dapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autofree char* hex_buf = NULL;
+	JHDF5Object_t* object = NULL;
+	JHDF5Object_t* parent = obj;
+	JHDF5Object_t* file;
+
+	g_return_val_if_fail(name != NULL, NULL);
+	g_return_val_if_fail(parent != NULL, NULL);
+
+	switch (parent->type)
+	{
+	case J_HDF5_OBJECT_TYPE_FILE:
+		file = parent;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		file = parent->dataset.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		file = parent->attr.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		file = parent->group.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_DATASET)))
+	{
+		j_goto_error();
+	}
+	object->dataset.statistics.min_value_i = 0;
+	object->dataset.statistics.max_value_i = 0;
+	object->dataset.statistics.min_value_f = 0;
+	object->dataset.statistics.max_value_f = 0;
+	if (!(object->dataset.name = g_strdup(name)))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.file = H5VL_julea_db_object_ref(file)))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.datatype = H5VL_julea_db_datatype_encode(&type_id)))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.space = H5VL_julea_db_space_encode(&space_id)))
+	{
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_dataset, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "file", file->backend_id, file->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "datatype", object->dataset.datatype->backend_id, object->dataset.datatype->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "space", object->dataset.space->backend_id, object->dataset.space->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_insert(entry, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_get_id(entry, &object->backend_id, &object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.distribution = j_distribution_new(J_DISTRIBUTION_ROUND_ROBIN)))
+	{
+		j_goto_error();
+	}
+	if (!(hex_buf = H5VL_julea_db_buf_to_hex("dataset", object->backend_id, object->backend_id_len)))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.object = j_distributed_object_new(JULEA_HDF5_DB_NAMESPACE, hex_buf, object->dataset.distribution)))
+	{
+		j_goto_error();
+	}
+	j_distributed_object_create(object->dataset.object, batch);
+	{
+		if (!j_batch_execute(batch))
+		{
+			j_goto_error();
+		}
+	}
+	if (!H5VL_julea_db_link_create_helper(parent, object, name))
+	{
+		j_goto_error();
+	}
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+static
+void*
+H5VL_julea_db_dataset_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name,
+	hid_t dapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autofree char* hex_buf = NULL;
+	g_autofree void* space_id_buf = NULL;
+	g_autofree void* datatype_id_buf = NULL;
+	JHDF5Object_t* object = NULL;
+	JHDF5Object_t* parent = obj;
+	JHDF5Object_t* file;
+	JDBType type;
+	guint64 len;
+	guint64 space_id_buf_len;
+	guint64 datatype_id_buf_len;
+	guint64* tmp_ptr_i;
+	gdouble* tmp_ptr_f;
+
+	g_return_val_if_fail(name != NULL, NULL);
+	g_return_val_if_fail(parent != NULL, NULL);
+
+	switch (parent->type)
+	{
+	case J_HDF5_OBJECT_TYPE_FILE:
+		file = parent;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		file = parent->dataset.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		file = parent->attr.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		file = parent->group.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_DATASET)))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.name = g_strdup(name)))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.file = H5VL_julea_db_object_ref(file)))
+	{
+		j_goto_error();
+	}
+	if (!H5VL_julea_db_link_get_helper(parent, object, name))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_dataset, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "_id", J_DB_SELECTOR_OPERATOR_EQ, object->backend_id, object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_dataset, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_next(iterator, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "min_value_i", &type, (gpointer*)&tmp_ptr_i, &len, &error))
+	{
+		j_goto_error();
+	}
+	object->dataset.statistics.min_value_i = *tmp_ptr_i;
+	g_free(tmp_ptr_i);
+	if (!j_db_iterator_get_field(iterator, "max_value_i", &type, (gpointer*)&tmp_ptr_i, &len, &error))
+	{
+		j_goto_error();
+	}
+	object->dataset.statistics.max_value_i = *tmp_ptr_i;
+	g_free(tmp_ptr_i);
+	if (!j_db_iterator_get_field(iterator, "min_value_f", &type, (gpointer*)&tmp_ptr_f, &len, &error))
+	{
+		j_goto_error();
+	}
+	object->dataset.statistics.min_value_f = *tmp_ptr_f;
+	g_free(tmp_ptr_f);
+	if (!j_db_iterator_get_field(iterator, "max_value_f", &type, (gpointer*)&tmp_ptr_f, &len, &error))
+	{
+		j_goto_error();
+	}
+	object->dataset.statistics.max_value_f = *tmp_ptr_f;
+	g_free(tmp_ptr_f);
+	if (!j_db_iterator_get_field(iterator, "space", &type, &space_id_buf, &space_id_buf_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.space = H5VL_julea_db_space_decode(space_id_buf, space_id_buf_len)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "datatype", &type, &datatype_id_buf, &datatype_id_buf_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.datatype = H5VL_julea_db_datatype_decode(datatype_id_buf, datatype_id_buf_len)))
+	{
+		j_goto_error();
+	}
+	g_assert(!j_db_iterator_next(iterator, NULL));
+	if (!(object->dataset.distribution = j_distribution_new(J_DISTRIBUTION_ROUND_ROBIN)))
+	{
+		j_goto_error();
+	}
+	if (!(hex_buf = H5VL_julea_db_buf_to_hex("dataset", object->backend_id, object->backend_id_len)))
+	{
+		j_goto_error();
+	}
+	if (!(object->dataset.object = j_distributed_object_new(JULEA_HDF5_DB_NAMESPACE, hex_buf, object->dataset.distribution)))
+	{
+		j_goto_error();
+	}
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+struct JHDF5IndexRange
+{
+	guint64 start;
+	guint64 stop;
+};
+typedef struct JHDF5IndexRange JHDF5IndexRange;
+
+static
+GArray*
+H5VL_julea_db_space_hdf5_to_range(hid_t mem_space_id, hid_t stored_space_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autofree hsize_t* stored_dims = NULL;
+	JHDF5IndexRange range;
+	JHDF5IndexRange range_tmp;
+	GArray* range_arr = NULL;
+	gboolean range_valid = FALSE;
+	gint stored_ndims;
+	guint i;
+	H5S_sel_type sel_type;
+	stored_ndims = H5Sget_simple_extent_ndims(stored_space_id);
+	stored_dims = g_new(hsize_t, stored_ndims);
+	H5Sget_simple_extent_dims(stored_space_id, stored_dims, NULL);
+	range_arr = g_array_new(FALSE, FALSE, sizeof(JHDF5IndexRange));
+	G_DEBUG_HERE();
+	if (mem_space_id == H5S_ALL)
+	{
+		sel_type = H5S_SEL_ALL;
+	}
+	else
+	{
+		sel_type = H5Sget_select_type(mem_space_id);
+	}
+	switch (sel_type)
+	{
+	case H5S_SEL_POINTS:
+	{
+		hssize_t npoints = 0;
+		hssize_t point_current = 0;
+		hssize_t point_current_index = 0;
+		g_autofree hsize_t* point_current_arr = NULL;
+		guint skipsize;
+
+		point_current_arr = g_new(hsize_t, stored_ndims);
+		if ((npoints = H5Sget_select_elem_npoints(mem_space_id)) <= 0)
+		{
+			j_goto_error();
+		}
+	_start:
+		while (point_current_index < npoints)
+		{
+			if (H5Sget_select_elem_pointlist(mem_space_id, point_current_index, 1, point_current_arr) < 0)
+			{
+				j_goto_error();
+			}
+			point_current = point_current_arr[stored_ndims - 1];
+			skipsize = stored_dims[stored_ndims - 1];
+			for (i = 2; i <= (guint)stored_ndims; i++)
+			{
+				point_current += point_current_arr[stored_ndims - i] * skipsize;
+				skipsize *= stored_dims[stored_ndims - i];
+			}
+			if (range_valid)
+			{
+				if ((guint64)point_current == range.stop + 1)
+				{
+					range.stop++;
+				}
+				else
+				{
+					g_array_append_val(range_arr, range);
+					range.start = point_current;
+					range.stop = point_current;
+				}
+			}
+			else
+			{
+				range.start = point_current;
+				range.stop = point_current;
+				range_valid = TRUE;
+				goto _start;
+			}
+			point_current_index++;
+		}
+		if (range_valid)
+		{
+			g_array_append_val(range_arr, range);
+		}
+	}
+	break;
+	case H5S_SEL_HYPERSLABS:
+	{
+		g_autofree hsize_t* hyperspab_counters = NULL;
+		g_autofree hsize_t* hyperspab_coordinates = NULL;
+		g_autofree hsize_t* hyperspab_skip_size = NULL;
+		hssize_t hyperslab_count;
+		hssize_t hyperslab_index;
+		gint current_counter;
+		gboolean found;
+		gboolean first;
+
+		if ((hyperslab_count = H5Sget_select_hyper_nblocks(mem_space_id)) < 0)
+		{
+			j_goto_error();
+		}
+		hyperspab_coordinates = g_new(hsize_t, stored_ndims * 2);
+		hyperspab_counters = g_new(hsize_t, stored_ndims);
+		hyperspab_skip_size = g_new(hsize_t, stored_ndims);
+		hyperspab_skip_size[stored_ndims - 1] = 1;
+		for (i = stored_ndims - 1; i > 0; i--)
+		{
+			hyperspab_skip_size[i - 1] = hyperspab_skip_size[i] * stored_dims[i];
+		}
+		//iterate over all hyperslabs
+		for (hyperslab_index = 0; hyperslab_index < hyperslab_count; hyperslab_index++)
+		{
+			if (H5Sget_select_hyper_blocklist(mem_space_id, hyperslab_index, 1, hyperspab_coordinates) < 0)
+			{
+				j_goto_error();
+			}
+
+			for (i = 0; i < (guint)stored_ndims; i++)
+			{
+				hyperspab_counters[i] = hyperspab_coordinates[i];
+			}
+			current_counter = stored_ndims - 1;
+			first = TRUE;
+			//within a hyperslab - iterate over the dimensions
+
+			do
+			{
+				//update current counter
+				found = FALSE;
+				while (current_counter >= 0)
+				{
+					if ((hyperspab_counters[current_counter] < hyperspab_coordinates[stored_ndims + current_counter]) || first)
+					{
+						found = TRUE;
+						first = FALSE;
+						break;
+					}
+					for (i = 0; i < (guint)stored_ndims; i++)
+					{
+						//reset counters
+						hyperspab_counters[current_counter] = hyperspab_coordinates[i];
+					}
+					current_counter--;
+				}
+				if (!found)
+				{
+					break;
+				}
+				//calculate output range
+				range_tmp.start = 0;
+				for (i = 0; i < (guint)stored_ndims; i++)
+				{
+					range_tmp.start += hyperspab_counters[i] * hyperspab_skip_size[i];
+				}
+				range_tmp.stop = range_tmp.start + hyperspab_coordinates[stored_ndims * 2 - 1] - hyperspab_coordinates[stored_ndims - 1];
+				if (!range_valid)
+				{
+					range.start = range_tmp.start;
+					range.stop = range_tmp.stop;
+					range_valid = TRUE;
+				}
+				else
+				{
+					if (range.stop + 1 == range_tmp.start)
+					{ //merge consecutive ranges
+						range.stop = range_tmp.stop;
+					}
+					else
+					{ //append range if the next has a gap
+						g_array_append_val(range_arr, range);
+						range.start = range_tmp.start;
+						range.stop = range_tmp.stop;
+					}
+				}
+				hyperspab_counters[current_counter]++;
+			} while (1);
+		}
+		if (range_valid)
+		{
+			g_array_append_val(range_arr, range);
+		}
+	}
+	break;
+	case H5S_SEL_ALL:
+	{
+		range.start = 0;
+		range.stop = 1;
+		for (i = 0; i < (guint)stored_ndims; i++)
+		{
+			range.stop *= stored_dims[i];
+		}
+		g_array_append_val(range_arr, range);
+	}
+	break;
+	case H5S_SEL_N:
+	case H5S_SEL_ERROR:
+	case H5S_SEL_NONE:
+	default:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	}
+	//TODO for speedup: sort the array of ranges and merge if possible
+	return range_arr;
+_error:
+	g_array_free(range_arr, TRUE);
+	return NULL;
+}
+
+#define calculate_statistics_helper(_buf, _target_extension)                                    \
+	do                                                                                      \
+	{                                                                                       \
+		for (i = 0; i < n; i++)                                                         \
+		{                                                                               \
+			if (_buf < object->dataset.statistics.min_value##_target_extension)     \
+				object->dataset.statistics.min_value##_target_extension = _buf; \
+			if (_buf > object->dataset.statistics.max_value##_target_extension)     \
+				object->dataset.statistics.max_value##_target_extension = _buf; \
+		}                                                                               \
+	} while (0)
+static
+void
+calculate_statistics(JHDF5Object_t* object, const void* buf, gsize bytes, hid_t memory_type)
+{
+	guint i;
+	guint n;
+	guint element_size = H5Tget_size(memory_type);
+	n = bytes / element_size;
+	if (H5Tget_class(memory_type) == H5T_FLOAT)
+	{
+		if (element_size == 4)
+		{
+			calculate_statistics_helper(((gdouble)((const gfloat*)buf)[i]), _f);
+		}
+		else if (element_size == 8)
+		{
+			calculate_statistics_helper(((const gdouble*)buf)[i], _f);
+		}
+	}
+	else if (H5Tget_class(memory_type) == H5T_INTEGER)
+	{
+		if (H5Tget_sign(memory_type) == H5T_SGN_NONE)
+		{
+			if (element_size == 1)
+			{
+				calculate_statistics_helper(((gint8)((const guint8*)buf)[i]), _i);
+			}
+			else if (element_size == 2)
+			{
+				calculate_statistics_helper(((gint16)((const guint16*)buf)[i]), _i);
+			}
+			else if (element_size == 4)
+			{
+				calculate_statistics_helper(((gint32)((const guint32*)buf)[i]), _i);
+			}
+			else if (element_size == 8)
+			{
+				calculate_statistics_helper(((gint64)((const guint64*)buf)[i]), _i);
+			}
+		}
+		else
+		{
+			if (element_size == 1)
+			{
+				calculate_statistics_helper(((const gint8*)buf)[i], _i);
+			}
+			else if (element_size == 2)
+			{
+				calculate_statistics_helper(((const gint16*)buf)[i], _i);
+			}
+			else if (element_size == 4)
+			{
+				calculate_statistics_helper(((const gint32*)buf)[i], _i);
+			}
+			else if (element_size == 8)
+			{
+				calculate_statistics_helper(((const gint64*)buf)[i], _i);
+			}
+		}
+	}
+}
+
+static
+herr_t
+H5VL_julea_db_dataset_write(void* obj, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id,
+	hid_t xfer_plist_id, const void* buf, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autofree void* local_buf_org = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GArray) mem_space_arr = NULL;
+	g_autoptr(GArray) file_space_arr = NULL;
+	const void* local_buf;
+	guint64 bytes_written;
+	gsize data_size;
+	gsize data_count;
+	JHDF5Object_t* object = obj;
+	guint mem_space_idx;
+	guint file_space_idx;
+	JHDF5IndexRange* mem_space_range = NULL;
+	JHDF5IndexRange* file_space_range = NULL;
+	guint64 current_count1;
+	guint64 current_count2;
+	guint i;
+
+	g_return_val_if_fail(buf != NULL, 1);
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_DATASET, 1);
+
+	data_size = object->dataset.datatype->datatype.type_total_size;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+
+	if (!(mem_space_arr = H5VL_julea_db_space_hdf5_to_range(mem_space_id, object->dataset.space->space.hdf5_id)))
+	{
+		j_goto_error();
+	}
+	if (!(file_space_arr = H5VL_julea_db_space_hdf5_to_range(file_space_id, object->dataset.space->space.hdf5_id)))
+	{
+		j_goto_error();
+	}
+
+	data_count = 0;
+	for (i = 0; i < mem_space_arr->len; i++)
+	{
+		mem_space_range = &g_array_index(mem_space_arr, JHDF5IndexRange, i);
+		data_count += mem_space_range->stop - mem_space_range->start;
+	}
+
+	local_buf_org = g_new(char, data_size* data_count);
+
+	local_buf = H5VL_julea_db_datatype_convert_type(mem_type_id, object->dataset.datatype->datatype.hdf5_id, buf, local_buf_org, data_count);
+	mem_space_idx = 0;
+	file_space_idx = 0;
+	while ((mem_space_idx < mem_space_arr->len) && (file_space_idx < file_space_arr->len))
+	{
+		if (mem_space_range == NULL)
+		{
+			mem_space_range = &g_array_index(mem_space_arr, JHDF5IndexRange, mem_space_idx++);
+		}
+		if (file_space_range == NULL)
+		{
+			file_space_range = &g_array_index(file_space_arr, JHDF5IndexRange, file_space_idx++);
+		}
+		current_count1 = mem_space_range->stop - mem_space_range->start;
+		current_count2 = file_space_range->stop - file_space_range->start;
+		current_count1 = current_count1 < current_count2 ? current_count1 : current_count2;
+		calculate_statistics(object, ((const char*)local_buf) + mem_space_range->start * data_size, data_size * current_count1, mem_type_id);
+		j_distributed_object_write(object->dataset.object, ((const char*)local_buf) + mem_space_range->start * data_size, data_size * current_count1, file_space_range->start * data_size, &bytes_written, batch);
+		if (mem_space_range->start + current_count1 == mem_space_range->stop)
+		{
+			mem_space_range = NULL;
+		}
+		if (file_space_range->start + current_count1 == file_space_range->stop)
+		{
+			file_space_range = NULL;
+		}
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	return 0;
+_error:
+	return 1;
+}
+static
+herr_t
+H5VL_julea_db_dataset_read(void* obj, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id,
+	hid_t xfer_plist_id, void* buf, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autofree void* local_buf_org = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GArray) mem_space_arr = NULL;
+	g_autoptr(GArray) file_space_arr = NULL;
+	const void* local_buf;
+	guint64 bytes_read;
+	gsize data_size;
+	gsize data_count;
+	JHDF5Object_t* object = obj;
+	guint mem_space_idx;
+	guint file_space_idx;
+	JHDF5IndexRange* mem_space_range = NULL;
+	JHDF5IndexRange* file_space_range = NULL;
+	guint64 current_count1;
+	guint64 current_count2;
+	guint i;
+
+	g_return_val_if_fail(buf != NULL, 1);
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_DATASET, 1);
+
+	data_size = object->dataset.datatype->datatype.type_total_size;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(mem_space_arr = H5VL_julea_db_space_hdf5_to_range(mem_space_id, object->dataset.space->space.hdf5_id)))
+	{
+		j_goto_error();
+	}
+	if (!(file_space_arr = H5VL_julea_db_space_hdf5_to_range(file_space_id, object->dataset.space->space.hdf5_id)))
+	{
+		j_goto_error();
+	}
+
+	data_count = 0;
+	for (i = 0; i < mem_space_arr->len; i++)
+	{
+		mem_space_range = &g_array_index(mem_space_arr, JHDF5IndexRange, i);
+		data_count += mem_space_range->stop - mem_space_range->start;
+	}
+
+	local_buf_org = g_new(char, data_size* data_count);
+
+	mem_space_idx = 0;
+	file_space_idx = 0;
+	while ((mem_space_idx < mem_space_arr->len) && (file_space_idx < file_space_arr->len))
+	{
+		if (mem_space_range == NULL)
+		{
+			mem_space_range = &g_array_index(mem_space_arr, JHDF5IndexRange, mem_space_idx++);
+		}
+		if (file_space_range == NULL)
+		{
+			file_space_range = &g_array_index(file_space_arr, JHDF5IndexRange, file_space_idx++);
+		}
+		current_count1 = mem_space_range->stop - mem_space_range->start;
+		current_count2 = file_space_range->stop - file_space_range->start;
+		current_count1 = current_count1 < current_count2 ? current_count1 : current_count2;
+		j_distributed_object_read(object->dataset.object, ((char*)buf) + mem_space_range->start * data_size, data_size * current_count1, file_space_range->start * data_size, &bytes_read, batch);
+		if (mem_space_range->start + current_count1 == mem_space_range->stop)
+		{
+			mem_space_range = NULL;
+		}
+		if (file_space_range->start + current_count1 == file_space_range->stop)
+		{
+			file_space_range = NULL;
+		}
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+
+	local_buf = H5VL_julea_db_datatype_convert_type(mem_type_id, object->dataset.datatype->datatype.hdf5_id, buf, local_buf_org, data_count);
+	if (local_buf != buf)
+	{
+		memcpy(buf, local_buf, data_size * data_count);
+	}
+	return 0;
+_error:
+	return 1;
+}
+static
+herr_t
+H5VL_julea_db_dataset_get(void* obj, H5VL_dataset_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_DATASET, 1);
+
+	switch (get_type)
+	{
+	case H5VL_DATASET_GET_SPACE:
+		*(va_arg(arguments, hid_t*)) = object->dataset.space->space.hdf5_id;
+		break;
+	case H5VL_DATASET_GET_TYPE:
+		*(va_arg(arguments, hid_t*)) = object->dataset.datatype->datatype.hdf5_id;
+		break;
+	case H5VL_DATASET_GET_DAPL:
+	case H5VL_DATASET_GET_DCPL:
+	case H5VL_DATASET_GET_OFFSET:
+	case H5VL_DATASET_GET_SPACE_STATUS:
+	case H5VL_DATASET_GET_STORAGE_SIZE:
+	default:
+		g_assert_not_reached();
+		exit(1);
+	}
+	return 0;
+}
+static
+herr_t
+H5VL_julea_db_dataset_specific(void* obj, H5VL_dataset_specific_t specific_type,
+	hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_DATASET, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_dataset_optional(void* obj, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_DATASET, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_dataset_close(void* obj, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	JHDF5Object_t* object = obj;
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_DATASET, 1);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_dataset, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "_id", J_DB_SELECTOR_OPERATOR_EQ, object->backend_id, object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_dataset, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "min_value_i", &object->dataset.statistics.min_value_i, sizeof(object->dataset.statistics.min_value_i), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "max_value_i", &object->dataset.statistics.max_value_i, sizeof(object->dataset.statistics.max_value_i), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "min_value_f", &object->dataset.statistics.min_value_f, sizeof(object->dataset.statistics.min_value_f), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "max_value_f", &object->dataset.statistics.max_value_f, sizeof(object->dataset.statistics.max_value_f), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_update(entry, selector, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	H5VL_julea_db_object_unref(object);
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return 1;
+}
+#pragma GCC diagnostic pop
+#endif

--- a/lib/hdf5-db/jhdf5-db-datatype.c
+++ b/lib/hdf5-db/jhdf5-db-datatype.c
@@ -1,0 +1,526 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+#ifndef JULEA_DB_HDF5_DATATYPE_C
+#define JULEA_DB_HDF5_DATATYPE_C
+
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "jhdf5-db.h"
+#include "jhdf5-db-shared.c"
+
+#define _GNU_SOURCE
+
+static
+JDBSchema* julea_db_schema_datatype_header = NULL;
+#define _bswap16(a, b) *(guint16*)b = (((*(const guint16*)a) & 0x00FF) << 8) | (((*(const guint16*)a) & 0xFF00) >> 8)
+#define _bswap32(a, b) *(guint32*)b = (((*(const guint32*)a) & 0x000000FF) << 24) | (((*(const guint32*)a) & 0x0000FF00) << 8) | (((*(const guint32*)a) & 0x00FF0000) >> 8) | (((*(const guint32*)a) & 0xFF000000) >> 24)
+#define _bswap64(a, b) *(guint64*)b = (((*(const guint64*)a) & 0x00000000000000FFULL) << 56) | (((*(const guint64*)a) & 0x000000000000FF00ULL) << 40) | (((*(const guint64*)a) & 0x0000000000FF0000ULL) << 24) | \
+	(((*(const guint64*)a) & 0x00000000FF000000ULL) << 8) | (((*(const guint64*)a) & 0x000000FF00000000ULL) >> 8) | (((*(const guint64*)a) & 0x0000FF0000000000ULL) >> 24) | (((*(const guint64*)a) & 0x00FF000000000000ULL) >> 40) | (((*(const guint64*)a) & 0xFF00000000000000ULL) >> 56)
+
+static
+const void*
+H5VL_julea_db_datatype_convert_type_change(hid_t type_id_from, hid_t type_id_to, const char* from_buf, char* target_buf, guint count)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_assert(H5Tget_class(type_id_from) == H5Tget_class(type_id_to));
+	g_assert(H5Tget_size(type_id_from) == H5Tget_size(type_id_to));
+	switch (H5Tget_class(type_id_from))
+	{
+	case H5T_FLOAT: // no conversion
+		break;
+	case H5T_INTEGER: // no conversion
+		break;
+	case H5T_STRING:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_BITFIELD:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_OPAQUE:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_COMPOUND:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_REFERENCE:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_ENUM:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_VLEN:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_ARRAY:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_NO_CLASS:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_TIME:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	case H5T_NCLASSES:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	default:
+		g_critical("%s NOT implemented !!", G_STRLOC);
+		abort();
+	}
+	return target_buf;
+}
+
+static
+const void*
+H5VL_julea_db_datatype_convert_type(hid_t type_id_from, hid_t type_id_to, const char* from_buf, char* tmp_buf, guint count)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (H5Tequal(type_id_from, type_id_to))
+	{
+		return from_buf;
+	}
+	return H5VL_julea_db_datatype_convert_type_change(type_id_from, type_id_to, from_buf, tmp_buf, count);
+}
+static
+herr_t
+H5VL_julea_db_datatype_term(void)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (julea_db_schema_datatype_header)
+	{
+		j_db_schema_unref(julea_db_schema_datatype_header);
+	}
+	julea_db_schema_datatype_header = NULL;
+	return 0;
+}
+static
+herr_t
+H5VL_julea_db_datatype_init(hid_t vipl_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+
+	if (!(julea_db_schema_datatype_header = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "datatype_header", NULL)))
+	{
+		j_goto_error();
+	}
+	if (!(j_db_schema_get(julea_db_schema_datatype_header, batch, &error) && j_batch_execute(batch)))
+	{
+		if (error)
+		{
+			if (error->code == J_BACKEND_DB_ERROR_SCHEMA_NOT_FOUND)
+			{
+				g_error_free(error);
+				error = NULL;
+				if (julea_db_schema_datatype_header)
+				{
+					j_db_schema_unref(julea_db_schema_datatype_header);
+				}
+				if (!(julea_db_schema_datatype_header = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "datatype_header", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_cache", J_DB_TYPE_BLOB, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_class", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_size", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_order", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_precision", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_offset", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_sign", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_ebias", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_norm", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_inpad", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_cset", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_datatype_header, "type_strpad", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_create(julea_db_schema_datatype_header, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+			}
+			else
+			{
+				g_assert_not_reached();
+				j_goto_error();
+			}
+		}
+		else
+		{
+			g_assert_not_reached();
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_datatype_term();
+	return 1;
+}
+
+static
+JHDF5Object_t*
+H5VL_julea_db_datatype_decode(void* backend_id, guint64 backend_id_len)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autofree guint32* tmp_uint32 = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	JHDF5Object_t* object = NULL;
+	JDBType type;
+	guint64 length;
+
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_DATATYPE)))
+	{
+		j_goto_error();
+	}
+	if (!(object->backend_id = g_new(char, backend_id_len)))
+	{
+		j_goto_error();
+	}
+	memcpy(object->backend_id, backend_id, backend_id_len);
+	object->backend_id_len = backend_id_len;
+
+	if (!(selector = j_db_selector_new(julea_db_schema_datatype_header, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "_id", J_DB_SELECTOR_OPERATOR_EQ, object->backend_id, object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_datatype_header, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_next(iterator, NULL))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "type_cache", &type, &object->datatype.data, &object->datatype.data_size, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "type_size", &type, (gpointer*)&tmp_uint32, &length, &error))
+	{
+		j_goto_error();
+	}
+	object->datatype.type_total_size = *tmp_uint32;
+	if (!(object->datatype.hdf5_id = H5Tdecode(object->datatype.data)))
+	{
+		j_goto_error();
+	}
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+
+static
+JHDF5Object_t*
+H5VL_julea_db_datatype_encode(hid_t* type_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	JHDF5Object_t* object = NULL;
+	JDBType type;
+	size_t size;
+	guint i;
+	H5T_class_t clazz;
+
+	g_return_val_if_fail(type_id != NULL, NULL);
+	g_return_val_if_fail(*type_id != -1, NULL);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+
+	//transform to binary
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_DATATYPE)))
+	{
+		j_goto_error();
+	}
+	object->datatype.type_total_size = H5Tget_size(*type_id);
+	H5Tencode(*type_id, NULL, &size);
+	if (!(object->datatype.data = g_new(char, size)))
+	{
+		j_goto_error();
+	}
+	H5Tencode(*type_id, object->datatype.data, &size);
+	object->datatype.hdf5_id = *type_id;
+
+	//check if this datatype exists
+	if (!(selector = j_db_selector_new(julea_db_schema_datatype_header, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "type_cache", J_DB_SELECTOR_OPERATOR_EQ, object->datatype.data, size, &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_datatype_header, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (j_db_iterator_next(iterator, NULL))
+	{
+		if (!j_db_iterator_get_field(iterator, "_id", &type, &object->backend_id, &object->backend_id_len, &error))
+		{
+			j_goto_error();
+		}
+		goto _done;
+	}
+
+	//create new datatype if it did not exist before
+	if (!(entry = j_db_entry_new(julea_db_schema_datatype_header, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "type_cache", object->datatype.data, size, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "type_size", &object->datatype.type_total_size, sizeof(object->datatype.type_total_size), &error))
+	{
+		j_goto_error();
+	}
+	i = clazz = H5Tget_class(*type_id);
+	if (!j_db_entry_set_field(entry, "type_class", &i, sizeof(i), &error))
+	{
+		j_goto_error();
+	}
+	i = H5Tget_order(*type_id);
+	if (!j_db_entry_set_field(entry, "type_order", &i, sizeof(i), &error))
+	{
+		j_goto_error();
+	}
+	i = H5Tget_precision(*type_id);
+	if (!j_db_entry_set_field(entry, "type_precision", &i, sizeof(i), &error))
+	{
+		j_goto_error();
+	}
+	i = H5Tget_offset(*type_id);
+	if (!j_db_entry_set_field(entry, "type_offset", &i, sizeof(i), &error))
+	{
+		j_goto_error();
+	}
+	if ((clazz != H5T_FLOAT))
+	{
+		i = H5Tget_sign(*type_id);
+		if (!j_db_entry_set_field(entry, "type_sign", &i, sizeof(i), &error))
+		{
+			j_goto_error();
+		}
+	}
+	if ((clazz != H5T_INTEGER))
+	{
+		i = H5Tget_ebias(*type_id);
+		if (!j_db_entry_set_field(entry, "type_ebias", &i, sizeof(i), &error))
+		{
+			j_goto_error();
+		}
+	}
+	if ((clazz != H5T_INTEGER))
+	{
+		i = H5Tget_norm(*type_id);
+		if (!j_db_entry_set_field(entry, "type_norm", &i, sizeof(i), &error))
+		{
+			j_goto_error();
+		}
+	}
+	if ((clazz != H5T_INTEGER))
+	{
+		i = H5Tget_inpad(*type_id);
+		if (!j_db_entry_set_field(entry, "type_inpad", &i, sizeof(i), &error))
+		{
+			j_goto_error();
+		}
+	}
+	if ((clazz != H5T_INTEGER) && (clazz != H5T_FLOAT))
+	{
+		i = H5Tget_cset(*type_id);
+		if (!j_db_entry_set_field(entry, "type_cset", &i, sizeof(i), &error))
+		{
+			j_goto_error();
+		}
+	}
+	if ((clazz != H5T_INTEGER) && (clazz != H5T_FLOAT))
+	{
+		i = H5Tget_strpad(*type_id);
+		if (!j_db_entry_set_field(entry, "type_strpad", &i, sizeof(i), &error))
+		{
+			j_goto_error();
+		}
+	}
+	if (!j_db_entry_insert(entry, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_get_id(entry, &object->backend_id, &object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+_done:
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+
+static
+void*
+H5VL_julea_db_datatype_commit(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t type_id,
+	hid_t lcpl_id, hid_t tcpl_id, hid_t tapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+void*
+H5VL_julea_db_datatype_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name,
+	hid_t tapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_datatype_get(void* obj, H5VL_datatype_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_datatype_specific(void* obj, H5VL_datatype_specific_t specific_type,
+	hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_datatype_optional(void* obj, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_datatype_close(void* dt, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+
+#pragma GCC diagnostic pop
+#endif

--- a/lib/hdf5-db/jhdf5-db-datatype.c
+++ b/lib/hdf5-db/jhdf5-db-datatype.c
@@ -36,10 +36,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "jhdf5-db.h"
 #include "jhdf5-db-shared.c"
 
@@ -521,6 +517,4 @@ H5VL_julea_db_datatype_close(void* dt, hid_t dxpl_id, void** req)
 	g_critical("%s NOT implemented !!", G_STRLOC);
 	abort();
 }
-
-#pragma GCC diagnostic pop
 #endif

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -1,0 +1,368 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+#ifndef JULEA_DB_HDF5_FILE_C
+#define JULEA_DB_HDF5_FILE_C
+
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "jhdf5-db.h"
+#include "jhdf5-db-shared.c"
+#include "jhdf5-db-dataset.c"
+#include "jhdf5-db-attr.c"
+#include "jhdf5-db-link.c"
+#include "jhdf5-db-group.c"
+
+#define _GNU_SOURCE
+
+static
+JDBSchema* julea_db_schema_file = NULL;
+
+static
+herr_t
+H5VL_julea_db_file_term(void)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (julea_db_schema_file)
+	{
+		j_db_schema_unref(julea_db_schema_file);
+	}
+	julea_db_schema_file = NULL;
+	return 0;
+}
+
+static
+herr_t
+H5VL_julea_db_file_init(hid_t vipl_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(julea_db_schema_file = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "file", NULL)))
+	{
+		j_goto_error();
+	}
+	if (!(j_db_schema_get(julea_db_schema_file, batch, &error) && j_batch_execute(batch)))
+	{
+		if (error)
+		{
+			if (error->code == J_BACKEND_DB_ERROR_SCHEMA_NOT_FOUND)
+			{
+				g_error_free(error);
+				error = NULL;
+				if (julea_db_schema_file)
+				{
+					j_db_schema_unref(julea_db_schema_file);
+				}
+				if (!(julea_db_schema_file = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "file", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_file, "name", J_DB_TYPE_STRING, &error))
+				{
+					j_goto_error();
+				}
+				{
+					const gchar* index[] = {
+						"name",
+						NULL,
+					};
+					if (!j_db_schema_add_index(julea_db_schema_file, index, &error))
+					{
+						j_goto_error();
+					}
+				}
+				if (!j_db_schema_create(julea_db_schema_file, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+			}
+			else
+			{
+				g_assert_not_reached();
+				j_goto_error();
+			}
+		}
+		else
+		{
+			g_assert_not_reached();
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_file_term();
+	abort();
+	return 1;
+}
+
+static
+void*
+H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id,
+	hid_t fapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	JHDF5Object_t* object = NULL;
+	JDBType type;
+	gboolean exist;
+
+	g_return_val_if_fail(name != NULL, NULL);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	//test for existing file
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_FILE)))
+	{
+		j_goto_error();
+	}
+	if (!(object->file.name = g_strdup(name)))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_file, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "name", J_DB_SELECTOR_OPERATOR_EQ, name, strlen(name), &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_file, selector, &error)))
+	{
+		j_goto_error();
+	}
+	exist = j_db_iterator_next(iterator, NULL);
+	if ((flags & H5F_ACC_EXCL) && exist)
+	{
+		//fail if file exists, and flags define it should not exist
+		j_goto_error();
+	}
+	//create new file
+	if (!exist)
+	{
+		if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_FILE)))
+		{
+			j_goto_error();
+		}
+		if (!(object->file.name = g_strdup(name)))
+		{
+			j_goto_error();
+		}
+		if (!(entry = j_db_entry_new(julea_db_schema_file, &error)))
+		{
+			j_goto_error();
+		}
+		if (!j_db_entry_set_field(entry, "name", name, strlen(name), &error))
+		{
+			j_goto_error();
+		}
+		if (!j_db_entry_insert(entry, batch, &error))
+		{
+			j_goto_error();
+		}
+		if (!j_batch_execute(batch))
+		{
+			j_goto_error();
+		}
+		if (!j_db_entry_get_id(entry, &object->backend_id, &object->backend_id_len, &error))
+		{
+			j_goto_error();
+		}
+	}
+	else
+	{
+		if (!j_db_iterator_get_field(iterator, "_id", &type, &object->backend_id, &object->backend_id_len, &error))
+		{
+			j_goto_error();
+		}
+		g_assert(!j_db_iterator_next(iterator, NULL));
+		if (flags & H5F_ACC_TRUNC)
+		{
+			if (H5VL_julea_db_group_truncate_file(object))
+			{
+				j_goto_error();
+			}
+			if (H5VL_julea_db_attr_truncate_file(object))
+			{
+				j_goto_error();
+			}
+			if (H5VL_julea_db_dataset_truncate_file(object))
+			{
+				j_goto_error();
+			}
+			if (H5VL_julea_db_link_truncate_file(object))
+			{
+				j_goto_error();
+			}
+		}
+	}
+	return object;
+_error:
+	H5VL_julea_db_object_unref(object);
+	H5VL_julea_db_error_handler(error);
+	return NULL;
+}
+static
+void*
+H5VL_julea_db_file_open(const char* name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	JHDF5Object_t* object = NULL;
+	JDBType type;
+	g_autofree void* value = NULL;
+
+	g_return_val_if_fail(name != NULL, NULL);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_FILE)))
+	{
+		j_goto_error();
+	}
+	if (!(object->file.name = g_strdup(name)))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_file, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "name", J_DB_SELECTOR_OPERATOR_EQ, name, strlen(name), &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_file, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_next(iterator, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "_id", &type, &object->backend_id, &object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	g_assert(!j_db_iterator_next(iterator, NULL));
+	return object;
+_error:
+	H5VL_julea_db_object_unref(object);
+	H5VL_julea_db_error_handler(error);
+	return NULL;
+}
+static
+herr_t
+H5VL_julea_db_file_get(void* obj, H5VL_file_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_FILE, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_file_specific(void* obj, H5VL_file_specific_t specific_type,
+	hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_FILE, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_file_optional(void* obj, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_FILE, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_file_close(void* obj, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_FILE, 1);
+
+	H5VL_julea_db_object_unref(object);
+	return 0;
+}
+#pragma GCC diagnostic pop
+#endif

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -36,10 +36,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "jhdf5-db.h"
 #include "jhdf5-db-shared.c"
 #include "jhdf5-db-dataset.c"
@@ -364,5 +360,4 @@ H5VL_julea_db_file_close(void* obj, hid_t dxpl_id, void** req)
 	H5VL_julea_db_object_unref(object);
 	return 0;
 }
-#pragma GCC diagnostic pop
 #endif

--- a/lib/hdf5-db/jhdf5-db-group.c
+++ b/lib/hdf5-db/jhdf5-db-group.c
@@ -1,0 +1,409 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#ifndef JULEA_DB_HDF5_GROUP_C
+#define JULEA_DB_HDF5_GROUP_C
+
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "jhdf5-db.h"
+#include "jhdf5-db-shared.c"
+#include "jhdf5-db-link.c"
+
+#define _GNU_SOURCE
+
+static
+JDBSchema* julea_db_schema_group = NULL;
+
+static
+herr_t
+H5VL_julea_db_group_term(void)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (julea_db_schema_group)
+	{
+		j_db_schema_unref(julea_db_schema_group);
+	}
+	julea_db_schema_group = NULL;
+	return 0;
+}
+static
+herr_t
+H5VL_julea_db_group_init(hid_t vipl_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(julea_db_schema_group = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "group", NULL)))
+	{
+		j_goto_error();
+	}
+	if (!(j_db_schema_get(julea_db_schema_group, batch, &error) && j_batch_execute(batch)))
+	{
+		if (error)
+		{
+			if (error->code == J_BACKEND_DB_ERROR_SCHEMA_NOT_FOUND)
+			{
+				g_error_free(error);
+				error = NULL;
+				if (julea_db_schema_group)
+				{
+					j_db_schema_unref(julea_db_schema_group);
+				}
+				if (!(julea_db_schema_group = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "group", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_group, "file", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				{
+					const gchar* index[] = {
+						"file",
+						NULL,
+					};
+					if (!j_db_schema_add_index(julea_db_schema_group, index, &error))
+					{
+						j_goto_error();
+					}
+				}
+				if (!j_db_schema_create(julea_db_schema_group, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+				if (julea_db_schema_group)
+				{
+					j_db_schema_unref(julea_db_schema_group);
+				}
+				if (!(julea_db_schema_group = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "group", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_get(julea_db_schema_group, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+			}
+			else
+			{
+				g_assert_not_reached();
+				j_goto_error();
+			}
+		}
+		else
+		{
+			g_assert_not_reached();
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return 1;
+}
+static
+herr_t
+H5VL_julea_db_group_truncate_file(void* obj)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	JHDF5Object_t* file = obj;
+
+	g_return_val_if_fail(file != NULL, 1);
+	g_return_val_if_fail(file->type == J_HDF5_OBJECT_TYPE_FILE, 1);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_group, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "file", J_DB_SELECTOR_OPERATOR_EQ, file->backend_id, file->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_group, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_delete(entry, selector, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		if (!error || error->code != J_BACKEND_DB_ERROR_ITERATOR_NO_MORE_ELEMENTS)
+		{
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return 1;
+}
+static
+void*
+H5VL_julea_db_group_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name,
+	hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autofree char* hex_buf = NULL;
+	JHDF5Object_t* object = NULL;
+	JHDF5Object_t* parent = obj;
+	JHDF5Object_t* file;
+
+	g_return_val_if_fail(name != NULL, NULL);
+	g_return_val_if_fail(parent != NULL, NULL);
+
+	switch (parent->type)
+	{
+	case J_HDF5_OBJECT_TYPE_FILE:
+		file = parent;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		file = parent->dataset.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		file = parent->attr.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		file = parent->group.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_GROUP)))
+	{
+		j_goto_error();
+	}
+	if (!(object->group.name = g_strdup(name)))
+	{
+		j_goto_error();
+	}
+	if (!(object->group.file = H5VL_julea_db_object_ref(file)))
+	{
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_group, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "file", file->backend_id, file->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_insert(entry, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_get_id(entry, &object->backend_id, &object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!H5VL_julea_db_link_create_helper(parent, object, name))
+	{
+		j_goto_error();
+	}
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+static
+void*
+H5VL_julea_db_group_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name,
+	hid_t gapl_id, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	JHDF5Object_t* object = NULL;
+	JHDF5Object_t* parent = obj;
+	JHDF5Object_t* file;
+
+	g_return_val_if_fail(name != NULL, NULL);
+	g_return_val_if_fail(parent != NULL, NULL);
+
+	switch (parent->type)
+	{
+	case J_HDF5_OBJECT_TYPE_FILE:
+		file = parent;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		file = parent->dataset.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		file = parent->attr.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		file = parent->group.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_GROUP)))
+	{
+		j_goto_error();
+	}
+	if (!(object->group.name = g_strdup(name)))
+	{
+		j_goto_error();
+	}
+	if (!(object->group.file = H5VL_julea_db_object_ref(file)))
+	{
+		j_goto_error();
+	}
+	if (!H5VL_julea_db_link_get_helper(parent, object, name))
+	{
+		j_goto_error();
+	}
+	return object;
+_error:
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+static
+herr_t
+H5VL_julea_db_group_get(void* obj, H5VL_group_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_GROUP, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_group_specific(void* obj, H5VL_group_specific_t specific_type,
+	hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_GROUP, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_group_optional(void* obj, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_GROUP, 1);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_group_close(void* obj, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object = obj;
+
+	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_GROUP, 1);
+
+	H5VL_julea_db_object_unref(object);
+	return 0;
+}
+
+#pragma GCC diagnostic pop
+#endif

--- a/lib/hdf5-db/jhdf5-db-group.c
+++ b/lib/hdf5-db/jhdf5-db-group.c
@@ -37,10 +37,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "jhdf5-db.h"
 #include "jhdf5-db-shared.c"
 #include "jhdf5-db-link.c"
@@ -404,6 +400,4 @@ H5VL_julea_db_group_close(void* obj, hid_t dxpl_id, void** req)
 	H5VL_julea_db_object_unref(object);
 	return 0;
 }
-
-#pragma GCC diagnostic pop
 #endif

--- a/lib/hdf5-db/jhdf5-db-link.c
+++ b/lib/hdf5-db/jhdf5-db-link.c
@@ -37,10 +37,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "jhdf5-db.h"
 #include "jhdf5-db-shared.c"
 
@@ -513,6 +509,4 @@ H5VL_julea_db_link_optional(void* obj, hid_t dxpl_id, void** req, va_list argume
 	g_critical("%s NOT implemented !!", G_STRLOC);
 	abort();
 }
-
-#pragma GCC diagnostic pop
 #endif

--- a/lib/hdf5-db/jhdf5-db-link.c
+++ b/lib/hdf5-db/jhdf5-db-link.c
@@ -1,0 +1,518 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#ifndef JULEA_DB_HDF5_LINK_C
+#define JULEA_DB_HDF5_LINK_C
+
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "jhdf5-db.h"
+#include "jhdf5-db-shared.c"
+
+#define _GNU_SOURCE
+
+static
+JDBSchema* julea_db_schema_link = NULL;
+
+static
+herr_t
+H5VL_julea_db_link_term(void)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (julea_db_schema_link)
+	{
+		j_db_schema_unref(julea_db_schema_link);
+	}
+	julea_db_schema_link = NULL;
+	return 0;
+}
+static
+herr_t
+H5VL_julea_db_link_init(hid_t vipl_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(julea_db_schema_link = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "link", NULL)))
+	{
+		j_goto_error();
+	}
+	if (!(j_db_schema_get(julea_db_schema_link, batch, &error) && j_batch_execute(batch)))
+	{
+		if (error)
+		{
+			if (error->code == J_BACKEND_DB_ERROR_SCHEMA_NOT_FOUND)
+			{
+				g_error_free(error);
+				error = NULL;
+				if (julea_db_schema_link)
+				{
+					j_db_schema_unref(julea_db_schema_link);
+				}
+				if (!(julea_db_schema_link = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "link", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_link, "file", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_link, "parent", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_link, "parent_type", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_link, "child", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_link, "child_type", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_link, "name", J_DB_TYPE_STRING, &error))
+				{
+					j_goto_error();
+				}
+				{
+					const gchar* index[] = {
+						"parent",
+						"parent_type",
+						"name",
+						NULL,
+					};
+					if (!j_db_schema_add_index(julea_db_schema_link, index, &error))
+					{
+						j_goto_error();
+					}
+				}
+				{
+					const gchar* index[] = {
+						"file",
+						NULL,
+					};
+					if (!j_db_schema_add_index(julea_db_schema_link, index, &error))
+					{
+						j_goto_error();
+					}
+				}
+				if (!j_db_schema_create(julea_db_schema_link, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+				if (julea_db_schema_link)
+				{
+					j_db_schema_unref(julea_db_schema_link);
+				}
+				if (!(julea_db_schema_link = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "link", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_get(julea_db_schema_link, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+			}
+			else
+			{
+				g_assert_not_reached();
+				j_goto_error();
+			}
+		}
+		else
+		{
+			g_assert_not_reached();
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return 1;
+}
+static
+herr_t
+H5VL_julea_db_link_truncate_file(void* obj)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JDBSelector) selector = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	JHDF5Object_t* file = obj;
+
+	g_return_val_if_fail(file != NULL, 1);
+	g_return_val_if_fail(file->type == J_HDF5_OBJECT_TYPE_FILE, 1);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_link, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "file", J_DB_SELECTOR_OPERATOR_EQ, file->backend_id, file->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_link, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_delete(entry, selector, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		if (!error || error->code != J_BACKEND_DB_ERROR_ITERATOR_NO_MORE_ELEMENTS)
+		{
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return 1;
+}
+static
+gboolean
+H5VL_julea_db_link_get_helper(JHDF5Object_t* parent, JHDF5Object_t* child, const char* name)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	JHDF5Object_t* file;
+	JDBType type;
+
+	g_return_val_if_fail(name != NULL, FALSE);
+	g_return_val_if_fail(parent != NULL, FALSE);
+	g_return_val_if_fail(child != NULL, FALSE);
+
+	switch (parent->type)
+	{
+	case J_HDF5_OBJECT_TYPE_FILE:
+		file = parent;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		file = parent->dataset.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		file = parent->attr.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		file = parent->group.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+	switch (child->type)
+	{
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		g_assert(file == child->dataset.file);
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		g_assert(file == child->attr.file);
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		g_assert(file == child->group.file);
+		break;
+	case J_HDF5_OBJECT_TYPE_FILE:
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+
+	if (!(selector = j_db_selector_new(julea_db_schema_link, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "parent", J_DB_SELECTOR_OPERATOR_EQ, parent->backend_id, parent->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "parent_type", J_DB_SELECTOR_OPERATOR_EQ, &parent->type, sizeof(parent->type), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "name", J_DB_SELECTOR_OPERATOR_EQ, name, strlen(name), &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_link, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_next(iterator, &error))
+	{ //name must exist for parent before
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "child", &type, &child->backend_id, &child->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	//TODO g_assert (iteartor->'child_type' == child->type)
+	g_assert(!j_db_iterator_next(iterator, NULL));
+	return TRUE;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return FALSE;
+}
+
+static
+gboolean
+H5VL_julea_db_link_create_helper(JHDF5Object_t* parent, JHDF5Object_t* child, const char* name)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	JHDF5Object_t* file;
+
+	g_return_val_if_fail(name != NULL, FALSE);
+	g_return_val_if_fail(parent != NULL, FALSE);
+	g_return_val_if_fail(child != NULL, FALSE);
+
+	switch (parent->type)
+	{
+	case J_HDF5_OBJECT_TYPE_FILE:
+		file = parent;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		file = parent->dataset.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		file = parent->attr.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		file = parent->group.file;
+		break;
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+	switch (child->type)
+	{
+	case J_HDF5_OBJECT_TYPE_DATASET:
+		g_assert(file == child->dataset.file);
+		break;
+	case J_HDF5_OBJECT_TYPE_ATTR:
+		g_assert(file == child->attr.file);
+		break;
+	case J_HDF5_OBJECT_TYPE_GROUP:
+		g_assert(file == child->group.file);
+		break;
+	case J_HDF5_OBJECT_TYPE_FILE:
+	case J_HDF5_OBJECT_TYPE_DATATYPE:
+	case J_HDF5_OBJECT_TYPE_SPACE:
+	case _J_HDF5_OBJECT_TYPE_COUNT:
+	default:
+		g_assert_not_reached();
+		j_goto_error();
+	}
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(selector = j_db_selector_new(julea_db_schema_link, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "parent", J_DB_SELECTOR_OPERATOR_EQ, parent->backend_id, parent->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "parent_type", J_DB_SELECTOR_OPERATOR_EQ, &parent->type, sizeof(parent->type), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "name", J_DB_SELECTOR_OPERATOR_EQ, name, strlen(name), &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_link, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (j_db_iterator_next(iterator, NULL))
+	{ //name must not exist for parent before
+		j_goto_error();
+	}
+	if (!(entry = j_db_entry_new(julea_db_schema_link, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "file", file->backend_id, file->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "parent", parent->backend_id, parent->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "parent_type", &parent->type, sizeof(parent->type), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "child", child->backend_id, child->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "child_type", &child->type, sizeof(child->type), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "name", name, strlen(name), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_insert(entry, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	return TRUE;
+_error:
+	H5VL_julea_db_error_handler(error);
+	return FALSE;
+}
+
+static
+herr_t
+H5VL_julea_db_link_create(H5VL_link_create_type_t create_type, void* obj, const H5VL_loc_params_t* loc_params,
+	hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void** req, va_list argumenmts)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_link_copy(void* src_obj, const H5VL_loc_params_t* loc_params1,
+	void* dst_obj, const H5VL_loc_params_t* loc_params2,
+	hid_t lcpl, hid_t lapl, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_link_move(void* src_obj, const H5VL_loc_params_t* loc_params1,
+	void* dst_obj, const H5VL_loc_params_t* loc_params2,
+	hid_t lcpl, hid_t lapl, hid_t dxpl_id, void** req)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_link_get(void* obj, const H5VL_loc_params_t* loc_params, H5VL_link_get_t get_type,
+	hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_link_specific(void* obj, const H5VL_loc_params_t* loc_params, H5VL_link_specific_t specific_type,
+	hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+static
+herr_t
+H5VL_julea_db_link_optional(void* obj, hid_t dxpl_id, void** req, va_list arguments)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_critical("%s NOT implemented !!", G_STRLOC);
+	abort();
+}
+
+#pragma GCC diagnostic pop
+#endif

--- a/lib/hdf5-db/jhdf5-db-shared.c
+++ b/lib/hdf5-db/jhdf5-db-shared.c
@@ -1,0 +1,169 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+#ifndef JULEA_DB_HDF5_SHARED_C
+#define JULEA_DB_HDF5_SHARED_C
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "jhdf5-db.h"
+
+#define _GNU_SOURCE
+
+#define JULEA_DB 530
+
+static
+char*
+H5VL_julea_db_buf_to_hex(const char* prefix, const char* buf, guint buf_len)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	const guint prefix_len = strlen(prefix);
+	char* str = g_new(char, buf_len * 2 + 1 + prefix_len);
+	unsigned const char* pin = (unsigned const char*)buf;
+	unsigned const char* pin_end = pin + buf_len;
+	const char* hex = "0123456789ABCDEF";
+	char* pout = str;
+
+	memcpy(str, prefix, prefix_len);
+	pout += prefix_len;
+	while (pin < pin_end)
+	{
+		*pout++ = hex[(*pin >> 4) & 0xF];
+		*pout++ = hex[(*pin++) & 0xF];
+	}
+	*pout = 0;
+	return str;
+}
+
+static
+void
+H5VL_julea_db_error_handler(GError* error)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (error)
+	{
+		g_debug("%s %d %s", g_quark_to_string(error->domain), error->code, error->message);
+	}
+}
+
+static
+JHDF5Object_t*
+H5VL_julea_db_object_ref(JHDF5Object_t* object)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_return_val_if_fail(object != NULL, NULL);
+
+	g_atomic_int_inc(&object->ref_count);
+	return object;
+}
+static
+JHDF5Object_t*
+H5VL_julea_db_object_new(JHDF5ObjectType type)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JHDF5Object_t* object;
+
+	g_return_val_if_fail(type < _J_HDF5_OBJECT_TYPE_COUNT, NULL);
+
+	object = g_new0(JHDF5Object_t, 1);
+	object->backend_id = NULL;
+	object->backend_id_len = 0;
+	object->ref_count = 1;
+	object->type = type;
+	return object;
+}
+static
+void
+H5VL_julea_db_object_unref(JHDF5Object_t* object)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (object && g_atomic_int_dec_and_test(&object->ref_count))
+	{
+		switch (object->type)
+		{
+		case J_HDF5_OBJECT_TYPE_FILE:
+			g_free(object->file.name);
+			break;
+		case J_HDF5_OBJECT_TYPE_DATASET:
+			H5VL_julea_db_object_unref(object->dataset.file);
+			g_free(object->dataset.name);
+			if (object->dataset.distribution)
+			{
+				j_distribution_unref(object->dataset.distribution);
+			}
+			if (object->dataset.object)
+			{
+				j_distributed_object_unref(object->dataset.object);
+			}
+			break;
+		case J_HDF5_OBJECT_TYPE_ATTR:
+			H5VL_julea_db_object_unref(object->attr.file);
+			g_free(object->attr.name);
+			if (object->attr.distribution)
+			{
+				j_distribution_unref(object->attr.distribution);
+			}
+			if (object->attr.object)
+			{
+				j_distributed_object_unref(object->attr.object);
+			}
+			break;
+		case J_HDF5_OBJECT_TYPE_GROUP:
+			H5VL_julea_db_object_unref(object->group.file);
+			g_free(object->group.name);
+			break;
+		case J_HDF5_OBJECT_TYPE_DATATYPE:
+			g_free(object->datatype.data);
+			break;
+		case J_HDF5_OBJECT_TYPE_SPACE:
+			g_free(object->space.data);
+			break;
+		case _J_HDF5_OBJECT_TYPE_COUNT:
+		default:
+			g_assert_not_reached();
+		}
+		g_free(object->backend_id);
+		g_free(object);
+	}
+}
+
+#pragma GCC diagnostic pop
+#endif

--- a/lib/hdf5-db/jhdf5-db-shared.c
+++ b/lib/hdf5-db/jhdf5-db-shared.c
@@ -35,10 +35,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "jhdf5-db.h"
 
 #define _GNU_SOURCE
@@ -164,6 +160,4 @@ H5VL_julea_db_object_unref(JHDF5Object_t* object)
 		g_free(object);
 	}
 }
-
-#pragma GCC diagnostic pop
 #endif

--- a/lib/hdf5-db/jhdf5-db-space.c
+++ b/lib/hdf5-db/jhdf5-db-space.c
@@ -1,0 +1,408 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#ifndef JULEA_DB_HDF5_SPACE_C
+#define JULEA_DB_HDF5_SPACE_C
+
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#include "jhdf5-db.h"
+#include "jhdf5-db-shared.c"
+
+#define _GNU_SOURCE
+
+static
+JDBSchema* julea_db_schema_space_header = NULL;
+static
+JDBSchema* julea_db_schema_space = NULL;
+
+static
+herr_t
+H5VL_julea_db_space_term(void)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (julea_db_schema_space_header)
+	{
+		j_db_schema_unref(julea_db_schema_space_header);
+	}
+	julea_db_schema_space_header = NULL;
+	if (julea_db_schema_space)
+	{
+		j_db_schema_unref(julea_db_schema_space);
+	}
+	julea_db_schema_space = NULL;
+	return 0;
+}
+static
+herr_t
+H5VL_julea_db_space_init(hid_t vipl_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	if (!(julea_db_schema_space_header = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "space_header", NULL)))
+	{
+		j_goto_error();
+	}
+	if (!(j_db_schema_get(julea_db_schema_space_header, batch, &error) && j_batch_execute(batch)))
+	{
+		if (error)
+		{
+			if (error->code == J_BACKEND_DB_ERROR_SCHEMA_NOT_FOUND)
+			{
+				g_error_free(error);
+				error = NULL;
+				if (julea_db_schema_space_header)
+				{
+					j_db_schema_unref(julea_db_schema_space_header);
+				}
+				if (!(julea_db_schema_space_header = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "space_header", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_space_header, "dim_cache", J_DB_TYPE_BLOB, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_space_header, "dim_count", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_space_header, "dim_total_count", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_create(julea_db_schema_space_header, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+			}
+			else
+			{
+				g_assert_not_reached();
+				j_goto_error();
+			}
+		}
+		else
+		{
+			g_assert_not_reached();
+			j_goto_error();
+		}
+	}
+	if (!(julea_db_schema_space = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "space", NULL)))
+	{
+		j_goto_error();
+	}
+	if (!(j_db_schema_get(julea_db_schema_space, batch, &error) && j_batch_execute(batch)))
+	{
+		if (error)
+		{
+			if (error->code == J_BACKEND_DB_ERROR_SCHEMA_NOT_FOUND)
+			{
+				g_error_free(error);
+				error = NULL;
+				if (julea_db_schema_space)
+				{
+					j_db_schema_unref(julea_db_schema_space);
+				}
+				if (!(julea_db_schema_space = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "space", NULL)))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_space, "dim_id", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_space, "dim_index", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_add_field(julea_db_schema_space, "dim_size", J_DB_TYPE_UINT32, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_db_schema_create(julea_db_schema_space, batch, &error))
+				{
+					j_goto_error();
+				}
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+			}
+			else
+			{
+				g_assert_not_reached();
+				j_goto_error();
+			}
+		}
+		else
+		{
+			g_assert_not_reached();
+			j_goto_error();
+		}
+	}
+	return 0;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_space_term();
+	return 1;
+}
+
+static
+JHDF5Object_t*
+H5VL_julea_db_space_decode(void* backend_id, guint64 backend_id_len)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autofree guint32* tmp_uint32 = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	JHDF5Object_t* object = NULL;
+	JDBType type;
+	guint64 length;
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_SPACE)))
+	{
+		j_goto_error();
+	}
+	if (!(object->backend_id = g_new(char, backend_id_len)))
+	{
+		j_goto_error();
+	}
+	memcpy(object->backend_id, backend_id, backend_id_len);
+	object->backend_id_len = backend_id_len;
+	if (!(selector = j_db_selector_new(julea_db_schema_space_header, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "_id", J_DB_SELECTOR_OPERATOR_EQ, object->backend_id, object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_space_header, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_next(iterator, NULL))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "dim_cache", &type, &object->space.data, &object->space.data_size, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_iterator_get_field(iterator, "dim_total_count", &type, (gpointer*)&tmp_uint32, &length, &error))
+	{
+		j_goto_error();
+	}
+	object->space.dim_total_count = *tmp_uint32;
+	object->space.hdf5_id = H5Sdecode(object->space.data);
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+
+static
+JHDF5Object_t*
+H5VL_julea_db_space_encode(hid_t* type_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_autofree hsize_t* stored_dims = NULL;
+	g_autoptr(JDBEntry) entry = NULL;
+	g_autoptr(JBatch) batch = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(JDBIterator) iterator = NULL;
+	g_autoptr(JDBSelector) selector = NULL;
+	gint stored_ndims;
+	guint element_count;
+	JHDF5Object_t* object = NULL;
+	JDBType type;
+	size_t size;
+	guint i;
+	guint j;
+
+	g_return_val_if_fail(type_id != NULL, NULL);
+	g_return_val_if_fail(*type_id != -1, NULL);
+
+	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
+	{
+		j_goto_error();
+	}
+	//transform to binary
+	{
+		J_TRACE("H5Sget_simple_extent_ndims", 0);
+		stored_ndims = H5Sget_simple_extent_ndims(*type_id);
+	}
+	stored_dims = g_new(hsize_t, stored_ndims);
+	{
+		J_TRACE("H5Sget_simple_extent_dims", 0);
+		H5Sget_simple_extent_dims(*type_id, stored_dims, NULL);
+	}
+	element_count = 1;
+	for (i = 0; i < (guint)stored_ndims; i++)
+	{
+		element_count *= stored_dims[i];
+	}
+	if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_SPACE)))
+	{
+		j_goto_error();
+	}
+	{
+		J_TRACE("H5SencodeNULL", 0);
+		H5Sencode(*type_id, NULL, &size);
+	}
+	if (!(object->space.data = g_new(char, size)))
+	{
+		j_goto_error();
+	}
+	{
+		J_TRACE("H5Sencode", 0);
+		H5Sencode(*type_id, object->space.data, &size);
+	}
+	object->space.hdf5_id = *type_id;
+	object->space.dim_total_count = element_count;
+
+	//check if this space exists
+	if (!(selector = j_db_selector_new(julea_db_schema_space_header, J_DB_SELECTOR_MODE_AND, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_selector_add_field(selector, "dim_cache", J_DB_SELECTOR_OPERATOR_EQ, object->space.data, size, &error))
+	{
+		j_goto_error();
+	}
+	if (!(iterator = j_db_iterator_new(julea_db_schema_space_header, selector, &error)))
+	{
+		j_goto_error();
+	}
+	if (j_db_iterator_next(iterator, NULL))
+	{
+		if (!j_db_iterator_get_field(iterator, "_id", &type, &object->backend_id, &object->backend_id_len, &error))
+		{
+			j_goto_error();
+		}
+		goto _done;
+	}
+
+	//create new space if it did not exist before
+	if (!(entry = j_db_entry_new(julea_db_schema_space_header, &error)))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "dim_cache", object->space.data, size, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "dim_count", &stored_ndims, sizeof(guint32), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_set_field(entry, "dim_total_count", &element_count, sizeof(guint32), &error))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_insert(entry, batch, &error))
+	{
+		j_goto_error();
+	}
+	if (!j_batch_execute(batch))
+	{
+		j_goto_error();
+	}
+	if (!j_db_entry_get_id(entry, &object->backend_id, &object->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+	for (i = 0; i < (guint)stored_ndims; i++)
+	{
+		if (entry)
+		{
+			j_db_entry_unref(entry);
+		}
+		entry = NULL;
+		if (!(entry = j_db_entry_new(julea_db_schema_space, &error)))
+		{
+			j_goto_error();
+		}
+		if (!j_db_entry_set_field(entry, "dim_id", object->backend_id, object->backend_id_len, &error))
+		{
+			j_goto_error();
+		}
+		if (!j_db_entry_set_field(entry, "dim_index", &i, sizeof(guint32), &error))
+		{
+			j_goto_error();
+		}
+		j = stored_dims[i];
+		if (!j_db_entry_set_field(entry, "dim_size", &j, sizeof(guint32), &error))
+		{
+			j_goto_error();
+		}
+		if (!j_db_entry_insert(entry, batch, &error))
+		{
+			j_goto_error();
+		}
+		if (!j_batch_execute(batch))
+		{
+			j_goto_error();
+		}
+	}
+_done:
+	return object;
+_error:
+	H5VL_julea_db_error_handler(error);
+	H5VL_julea_db_object_unref(object);
+	return NULL;
+}
+
+#pragma GCC diagnostic pop
+#endif

--- a/lib/hdf5-db/jhdf5-db-space.c
+++ b/lib/hdf5-db/jhdf5-db-space.c
@@ -37,10 +37,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "jhdf5-db.h"
 #include "jhdf5-db-shared.c"
 
@@ -403,6 +399,4 @@ _error:
 	H5VL_julea_db_object_unref(object);
 	return NULL;
 }
-
-#pragma GCC diagnostic pop
 #endif

--- a/lib/hdf5-db/jhdf5-db.c
+++ b/lib/hdf5-db/jhdf5-db.c
@@ -20,8 +20,6 @@
  * \file
  **/
 
-#define JULEA_HDF5_MAIN_COMPILES
-
 #include <julea-config.h>
 #include <julea.h>
 #include <julea-db.h>
@@ -40,9 +38,6 @@
 
 #include <hdf5.h>
 #include <H5PLextern.h>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 
 static
 herr_t
@@ -377,5 +372,3 @@ j_hdf5_set_semantics(JSemantics* semantics)
 	g_debug("julea-db j_hdf5_set_semantics");
 	//TODO FIXME implement this
 }
-
-#pragma GCC diagnostic pop

--- a/lib/hdf5-db/jhdf5-db.c
+++ b/lib/hdf5-db/jhdf5-db.c
@@ -1,0 +1,381 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#define JULEA_HDF5_MAIN_COMPILES
+
+#include <julea-config.h>
+#include <julea.h>
+#include <julea-db.h>
+#include <julea-object.h>
+#include <glib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#define H5Sencode_vers 1
+
+#include <hdf5.h>
+#include <H5PLextern.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+static
+herr_t
+H5VL_julea_db_attr_init(hid_t vipl_id);
+static
+herr_t
+H5VL_julea_db_attr_term(void);
+static
+herr_t
+H5VL_julea_db_dataset_init(hid_t vipl_id);
+static
+herr_t
+H5VL_julea_db_dataset_term(void);
+static
+herr_t
+H5VL_julea_db_datatype_init(hid_t vipl_id);
+static
+herr_t
+H5VL_julea_db_datatype_term(void);
+static
+herr_t
+H5VL_julea_db_file_init(hid_t vipl_id);
+static
+herr_t
+H5VL_julea_db_file_term(void);
+static
+herr_t
+H5VL_julea_db_group_init(hid_t vipl_id);
+static
+herr_t
+H5VL_julea_db_group_term(void);
+static
+herr_t
+H5VL_julea_db_space_init(hid_t vipl_id);
+static
+herr_t
+H5VL_julea_db_space_term(void);
+static
+herr_t
+H5VL_julea_db_link_init(hid_t vipl_id);
+static
+herr_t
+H5VL_julea_db_link_term(void);
+
+#include "jhdf5-db.h"
+#include "jhdf5-db-shared.c"
+#include "jhdf5-db-file.c"
+#include "jhdf5-db-dataset.c"
+#include "jhdf5-db-attr.c"
+#include "jhdf5-db-group.c"
+#include "jhdf5-db-datatype.c"
+#include "jhdf5-db-space.c"
+#include "jhdf5-db-link.c"
+
+#define _GNU_SOURCE
+
+#define JULEA_DB 530
+
+static
+herr_t
+H5VL_julea_db_init(hid_t vipl_id)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (H5VL_julea_db_file_init(vipl_id))
+	{
+		G_DEBUG_HERE();
+		goto _error_file;
+	}
+	if (H5VL_julea_db_dataset_init(vipl_id))
+	{
+		G_DEBUG_HERE();
+		goto _error_dataset;
+	}
+	if (H5VL_julea_db_attr_init(vipl_id))
+	{
+		G_DEBUG_HERE();
+		goto _error_attr;
+	}
+	if (H5VL_julea_db_datatype_init(vipl_id))
+	{
+		G_DEBUG_HERE();
+		goto _error_datatype;
+	}
+	if (H5VL_julea_db_group_init(vipl_id))
+	{
+		G_DEBUG_HERE();
+		goto _error_group;
+	}
+	if (H5VL_julea_db_space_init(vipl_id))
+	{
+		G_DEBUG_HERE();
+		goto _error_space;
+	}
+	if (H5VL_julea_db_link_init(vipl_id))
+	{
+		G_DEBUG_HERE();
+		goto _error_link;
+	}
+
+	return 0;
+_error_link:
+	H5VL_julea_db_link_term();
+_error_space:
+	H5VL_julea_db_space_term();
+_error_group:
+	H5VL_julea_db_group_term();
+_error_datatype:
+	H5VL_julea_db_datatype_term();
+_error_attr:
+	H5VL_julea_db_attr_term();
+_error_dataset:
+	H5VL_julea_db_dataset_term();
+_error_file:
+	H5VL_julea_db_file_term();
+
+	return 1;
+}
+
+static
+herr_t
+H5VL_julea_db_term(void)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	if (H5VL_julea_db_link_term())
+	{
+		j_goto_error();
+	}
+	if (H5VL_julea_db_space_term())
+	{
+		j_goto_error();
+	}
+	if (H5VL_julea_db_group_term())
+	{
+		j_goto_error();
+	}
+	if (H5VL_julea_db_datatype_term())
+	{
+		j_goto_error();
+	}
+	if (H5VL_julea_db_attr_term())
+	{
+		j_goto_error();
+	}
+	if (H5VL_julea_db_dataset_term())
+	{
+		j_goto_error();
+	}
+	if (H5VL_julea_db_file_term())
+	{
+		j_goto_error();
+	}
+	return 0;
+_error:
+	return 1;
+}
+
+/**
+ * The class providing the functions to HDF5
+ * @see dependencies/opt/spack/linux-ubuntu19.04-x86_64/gcc-8.3.0/hdf5-develop-4iami4kalqj7xgv2x2uv25dnzvz4xzwf/include/H5VLconnector.h
+ **/
+static
+const H5VL_class_t H5VL_julea_db_g = {
+	.version = 0,
+	.value = JULEA_DB,
+	.name = "julea-db",
+	.cap_flags = 0,
+	.initialize = H5VL_julea_db_init,
+	.terminate = H5VL_julea_db_term,
+	.info_cls = {
+		.size = 0,
+		.copy = NULL,
+		.cmp = NULL,
+		.free = NULL,
+		.to_str = NULL,
+		.from_str = NULL,
+	},
+	.wrap_cls = {
+		.get_object = NULL,
+		.get_wrap_ctx = NULL,
+		.wrap_object = NULL,
+		.unwrap_object = NULL,
+		.free_wrap_ctx = NULL,
+	},
+	.attr_cls = {
+		.create = H5VL_julea_db_attr_create,
+		.open = H5VL_julea_db_attr_open,
+		.read = H5VL_julea_db_attr_read,
+		.write = H5VL_julea_db_attr_write,
+		.get = H5VL_julea_db_attr_get,
+		.specific = H5VL_julea_db_attr_specific,
+		.optional = H5VL_julea_db_attr_optional,
+		.close = H5VL_julea_db_attr_close,
+	},
+	.dataset_cls = {
+		.create = H5VL_julea_db_dataset_create,
+		.open = H5VL_julea_db_dataset_open,
+		.read = H5VL_julea_db_dataset_read,
+		.write = H5VL_julea_db_dataset_write,
+		.get = H5VL_julea_db_dataset_get,
+		.specific = H5VL_julea_db_dataset_specific,
+		.optional = H5VL_julea_db_dataset_optional,
+		.close = H5VL_julea_db_dataset_close,
+	},
+	.datatype_cls = {
+		.commit = H5VL_julea_db_datatype_commit,
+		.open = H5VL_julea_db_datatype_open,
+		.get = H5VL_julea_db_datatype_get,
+		.specific = H5VL_julea_db_datatype_specific,
+		.optional = H5VL_julea_db_datatype_optional,
+		.close = H5VL_julea_db_datatype_close,
+	},
+	.file_cls = {
+		.create = H5VL_julea_db_file_create,
+		.open = H5VL_julea_db_file_open,
+		.get = H5VL_julea_db_file_get,
+		.specific = H5VL_julea_db_file_specific,
+		.optional = H5VL_julea_db_file_optional,
+		.close = H5VL_julea_db_file_close,
+	},
+	.group_cls = {
+		.create = H5VL_julea_db_group_create,
+		.open = H5VL_julea_db_group_open,
+		.get = H5VL_julea_db_group_get,
+		.specific = H5VL_julea_db_group_specific,
+		.optional = H5VL_julea_db_group_optional,
+		.close = H5VL_julea_db_group_close,
+	},
+	.link_cls = {
+		.create = H5VL_julea_db_link_create,
+		.copy = H5VL_julea_db_link_copy,
+		.move = H5VL_julea_db_link_move,
+		.get = H5VL_julea_db_link_get,
+		.specific = H5VL_julea_db_link_specific,
+		.optional = H5VL_julea_db_link_optional,
+	},
+	.object_cls = {
+		.open = NULL,
+		.copy = NULL,
+		.get = NULL,
+		.specific = NULL,
+		.optional = NULL,
+	},
+	.request_cls = {
+		.wait = NULL,
+		.notify = NULL,
+		.cancel = NULL,
+		.specific = NULL,
+		.optional = NULL,
+		.free = NULL,
+	},
+	.optional = NULL
+};
+
+static
+hid_t j_hdf5_fapl = -1;
+static
+hid_t j_hdf5_vol = -1;
+
+static
+void __attribute__((constructor)) j_hdf5_init(void);
+static
+void __attribute__((destructor)) j_hdf5_fini(void);
+
+/**
+ * Provides the plugin type
+ **/
+H5PL_type_t
+H5PLget_plugin_type(void)
+{
+	g_debug("julea-db H5PLget_plugin_type");
+	return H5PL_TYPE_VOL;
+}
+
+/**
+ * Provides a pointer to the plugin structure
+ **/
+const void*
+H5PLget_plugin_info(void)
+{
+	g_debug("julea-db H5PLget_plugin_info");
+	return &H5VL_julea_db_g;
+}
+
+static
+void
+j_hdf5_init(void)
+{
+	if ((j_hdf5_fapl != -1) && (j_hdf5_vol != -1))
+	{
+		return;
+	}
+	g_debug("julea-db j_hdf5_init");
+	j_hdf5_vol = H5VLregister_connector(&H5VL_julea_db_g, H5P_DEFAULT);
+	g_assert(j_hdf5_vol > 0);
+	g_assert(H5VLis_connector_registered("julea-db") == 1);
+
+	H5VLinitialize(j_hdf5_vol, H5P_DEFAULT);
+
+	j_hdf5_fapl = H5Pcreate(H5P_FILE_ACCESS);
+	H5Pset_vol(j_hdf5_fapl, j_hdf5_vol, NULL);
+}
+
+static
+void
+j_hdf5_fini(void)
+{
+	if ((j_hdf5_fapl == -1) && (j_hdf5_vol == -1))
+	{
+		return;
+	}
+	g_debug("julea-db j_hdf5_fini");
+	H5Pclose(j_hdf5_fapl);
+
+	H5VLterminate(j_hdf5_vol);
+
+	H5VLunregister_connector(j_hdf5_vol);
+	g_assert(H5VLis_connector_registered("julea-db") == 0);
+}
+
+hid_t
+j_hdf5_get_fapl(void)
+{
+	g_debug("julea-db j_hdf5_get_fapl");
+	return j_hdf5_fapl;
+}
+
+void
+j_hdf5_set_semantics(JSemantics* semantics)
+{
+	g_debug("julea-db j_hdf5_set_semantics");
+	//TODO FIXME implement this
+}
+
+#pragma GCC diagnostic pop

--- a/lib/hdf5-db/jhdf5-db.h
+++ b/lib/hdf5-db/jhdf5-db.h
@@ -1,0 +1,133 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2019 Benjamin Warnke
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#ifndef H5VL_JULEA_DB_H
+#define H5VL_JULEA_DB_H
+
+#define H5Sencode_vers 1
+
+#include <hdf5.h>
+#include <H5PLextern.h>
+
+#define JULEA_HDF5_DB_NAMESPACE "HDF5_DB"
+
+enum JHDF5ObjectType
+{
+	J_HDF5_OBJECT_TYPE_FILE = 0,
+	J_HDF5_OBJECT_TYPE_DATASET,
+	J_HDF5_OBJECT_TYPE_ATTR,
+	J_HDF5_OBJECT_TYPE_DATATYPE,
+	J_HDF5_OBJECT_TYPE_SPACE,
+	J_HDF5_OBJECT_TYPE_GROUP,
+	_J_HDF5_OBJECT_TYPE_COUNT
+};
+
+typedef enum JHDF5ObjectType JHDF5ObjectType;
+
+typedef struct JHDF5Object_t JHDF5Object_t;
+struct JHDF5Object_t
+{
+	gint ref_count;
+	JHDF5ObjectType type;
+	void* backend_id;
+	guint64 backend_id_len;
+	union
+	{
+		struct
+		{
+			char* name;
+		} file;
+		struct
+		{
+			char* name;
+			JHDF5Object_t* file;
+			JHDF5Object_t* datatype;
+			JHDF5Object_t* space;
+			JDistribution* distribution;
+			JDistributedObject* object;
+			struct
+			{
+				gint64 min_value_i;
+				gdouble min_value_f;
+				gint64 max_value_i;
+				gdouble max_value_f;
+			} statistics;
+		} dataset;
+		struct
+		{
+			char* name;
+			JHDF5Object_t* file;
+			JHDF5Object_t* datatype;
+			JHDF5Object_t* space;
+			JDistribution* distribution;
+			JDistributedObject* object;
+		} attr;
+		struct
+		{
+			char* name;
+			JHDF5Object_t* file;
+		} group;
+		struct
+		{
+			void* data;
+			size_t data_size;
+			guint type_total_size;
+			hid_t hdf5_id;
+		} datatype;
+		struct
+		{
+			void* data;
+			size_t data_size;
+			guint dim_total_count;
+			hid_t hdf5_id;
+		} space;
+	};
+};
+
+/*internal helper functions*/
+
+static
+void
+H5VL_julea_db_error_handler(GError* error);
+static
+char*
+H5VL_julea_db_buf_to_hex(const char* prefix, const char* buf, guint buf_len);
+
+static
+JHDF5Object_t*
+H5VL_julea_db_object_new(JHDF5ObjectType type);
+static
+JHDF5Object_t*
+H5VL_julea_db_object_ref(JHDF5Object_t* object);
+static
+void
+H5VL_julea_db_object_unref(JHDF5Object_t* object);
+
+#define j_goto_error()                   \
+	do                               \
+	{                                \
+		G_DEBUG_HERE();          \
+		g_debug("goto _error;"); \
+		goto _error;             \
+	} while (0)
+
+#endif

--- a/lib/hdf5/jhdf5.c
+++ b/lib/hdf5/jhdf5.c
@@ -1497,7 +1497,7 @@ H5VL_class_t H5VL_julea_g =
 {
 	0,
 	JULEA,
-	"julea",	  /* name */
+	"julea-kv", /* name */
 	0,
 	H5VL_julea_init, /* initialize */
 	H5VL_julea_term, /* terminate */
@@ -1647,7 +1647,7 @@ j_hdf5_init (void)
 	julea_h5vl = H5PLget_plugin_info();
 	j_hdf5_vol = H5VLregister_connector(julea_h5vl, H5P_DEFAULT);
 	g_assert(j_hdf5_vol > 0);
-	g_assert(H5VLis_connector_registered("julea") == 1);
+	g_assert(H5VLis_connector_registered("julea-kv") == 1);
 
 	H5VLinitialize(j_hdf5_vol, H5P_DEFAULT);
 
@@ -1676,7 +1676,7 @@ j_hdf5_fini (void)
 	H5VLterminate(j_hdf5_vol);
 
 	H5VLunregister_connector(j_hdf5_vol);
-	g_assert(H5VLis_connector_registered("julea") == 0);
+	g_assert(H5VLis_connector_registered("julea-kv") == 0);
 }
 
 hid_t

--- a/wscript
+++ b/wscript
@@ -454,6 +454,7 @@ def build(ctx):
 	use_julea_db = use_julea_core + ['lib/julea', 'lib/julea-db']
 	use_julea_item = use_julea_core + ['lib/julea', 'lib/julea-item']
 	use_julea_hdf = use_julea_core + ['lib/julea'] + ['lib/julea-hdf5'] if ctx.env.JULEA_HDF else []
+	use_julea_hdf_db = use_julea_core + ['lib/julea'] + ['lib/julea-hdf5-db'] if ctx.env.JULEA_HDF else []
 
 	include_julea_core = ['include', 'include/core']
 
@@ -471,6 +472,7 @@ def build(ctx):
 
 	if ctx.env.JULEA_HDF:
 		clients.append('hdf5')
+		clients.append('hdf5-db')
 
 	for client in clients:
 		use_extra = []
@@ -482,6 +484,12 @@ def build(ctx):
 			use_extra.append('HDF5')
 			use_extra.append('lib/julea-kv')
 			use_extra.append('lib/julea-object')
+		elif client == 'hdf5-db':
+			use_extra.append('HDF5DB')
+			use_extra.append('SQLITE')
+			use_extra.append('lib/julea-kv')
+			use_extra.append('lib/julea-object')
+			use_extra.append('lib/julea-db')
 
 		ctx.shlib(
 			source=ctx.path.ant_glob('lib/{0}/**/*.c'.format(client)),
@@ -497,7 +505,7 @@ def build(ctx):
 	ctx.program(
 		source=ctx.path.ant_glob('test/**/*.c'),
 		target='test/julea-test',
-		use=use_julea_object + use_julea_kv + use_julea_db + use_julea_item + use_julea_hdf,
+		use=use_julea_object + use_julea_kv + use_julea_db + use_julea_item + use_julea_hdf + use_julea_hdf_db,
 		includes=include_julea_core + ['test'],
 		rpath=get_rpath(ctx),
 		install_path=None
@@ -507,7 +515,7 @@ def build(ctx):
 	ctx.program(
 		source=ctx.path.ant_glob('benchmark/**/*.c'),
 		target='benchmark/julea-benchmark',
-		use=use_julea_object + use_julea_kv + use_julea_item + use_julea_hdf,
+		use=use_julea_object + use_julea_kv + use_julea_item + use_julea_hdf + use_julea_hdf_db + use_julea_db,
 		includes=include_julea_core + ['benchmark'],
 		rpath=get_rpath(ctx),
 		install_path=None

--- a/wscript
+++ b/wscript
@@ -486,10 +486,8 @@ def build(ctx):
 			use_extra.append('lib/julea-object')
 		elif client == 'hdf5-db':
 			use_extra.append('HDF5DB')
-			use_extra.append('SQLITE')
-			use_extra.append('lib/julea-kv')
-			use_extra.append('lib/julea-object')
 			use_extra.append('lib/julea-db')
+			use_extra.append('lib/julea-object')
 
 		ctx.shlib(
 			source=ctx.path.ant_glob('lib/{0}/**/*.c'.format(client)),


### PR DESCRIPTION
The design of "j_hdf5_get_fapl" and "j_hdf5_set_semantics" needs to be reworked somehow, to allow multiple different julea-hdf-plugins to exist simultaneously

Maybe some components of the kv and db hdf vol plugins might be merged