### PR TITLE
Code might stuck in a cyclic call

### DIFF
--- a/backend/db/sql-generic.c
+++ b/backend/db/sql-generic.c
@@ -970,7 +970,7 @@ backend_schema_create(gpointer backend_data, gpointer _batch, gchar const* name,
 _error:
 	if (G_UNLIKELY(!_backend_batch_start(backend_data, batch, NULL)))
 	{
-		goto _error;
+		goto _error2;
 	}
 
 	if (sql)
@@ -978,6 +978,9 @@ _error:
 		g_string_free(sql, TRUE);
 	}
 
+	return FALSE;
+
+_error2:
 	return FALSE;
 }
 


### PR DESCRIPTION
Inside the label _error (Line 970), keyword goto was called again for the same label (i.e. _error) which might freeze the application in a recursive call. In the other methods in this file, another label is used in such situations where failure is expected inside _error label, therefore, I, by following the norm, have added another label - but needs a better fix - at least a self-describing label name should be used.