### PR TITLE
Workarround for missing id in new schemas in jdf5-db

### DIFF
--- a/lib/hdf5-db/jhdf5-db-attr.c
+++ b/lib/hdf5-db/jhdf5-db-attr.c
@@ -149,6 +149,7 @@ H5VL_julea_db_attr_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
+				// FIXME Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_attr, batch, &error))
 				{
 					j_goto_error();

--- a/lib/hdf5-db/jhdf5-db-dataset.c
+++ b/lib/hdf5-db/jhdf5-db-dataset.c
@@ -164,6 +164,7 @@ H5VL_julea_db_dataset_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
+				// FIXME Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_dataset, batch, &error))
 				{
 					j_goto_error();

--- a/lib/hdf5-db/jhdf5-db-datatype.c
+++ b/lib/hdf5-db/jhdf5-db-datatype.c
@@ -217,6 +217,27 @@ H5VL_julea_db_datatype_init(hid_t vipl_id)
 				{
 					j_goto_error();
 				}
+
+				if (julea_db_schema_datatype_header)
+				{
+					j_db_schema_unref(julea_db_schema_datatype_header);
+				}
+
+				if (!(julea_db_schema_datatype_header = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "datatype_header", NULL)))
+				{
+					j_goto_error();
+				}
+
+				// FIXME Use same key type for every db backend to remove get for every new schema.
+				if (!j_db_schema_get(julea_db_schema_datatype_header, batch, &error))
+				{
+					j_goto_error();
+				}
+
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
 			}
 			else
 			{

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -123,6 +123,27 @@ H5VL_julea_db_file_init(hid_t vipl_id)
 				{
 					j_goto_error();
 				}
+
+				if (julea_db_schema_file)
+				{
+					j_db_schema_unref(julea_db_schema_file);
+				}
+
+				if (!(julea_db_schema_file = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "file", NULL)))
+				{
+					j_goto_error();
+				}
+
+				// FIXME Use same key type for every db backend to remove get for every new schema.
+				if (!j_db_schema_get(julea_db_schema_file, batch, &error))
+				{
+					j_goto_error();
+				}
+
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
 			}
 			else
 			{

--- a/lib/hdf5-db/jhdf5-db-group.c
+++ b/lib/hdf5-db/jhdf5-db-group.c
@@ -134,6 +134,7 @@ H5VL_julea_db_group_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
+				// FIXME Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_group, batch, &error))
 				{
 					j_goto_error();

--- a/lib/hdf5-db/jhdf5-db-link.c
+++ b/lib/hdf5-db/jhdf5-db-link.c
@@ -173,6 +173,7 @@ H5VL_julea_db_link_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
+				// FIXME Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_link, batch, &error))
 				{
 					j_goto_error();

--- a/lib/hdf5-db/jhdf5-db-space.c
+++ b/lib/hdf5-db/jhdf5-db-space.c
@@ -128,6 +128,27 @@ H5VL_julea_db_space_init(hid_t vipl_id)
 				{
 					j_goto_error();
 				}
+
+				if (julea_db_schema_space_header)
+				{
+					j_db_schema_unref(julea_db_schema_space_header);
+				}
+
+				if (!(julea_db_schema_space_header = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "space_header", NULL)))
+				{
+					j_goto_error();
+				}
+
+				// FIXME Use same key type for every db backend to remove get for every new schema.
+				if (!j_db_schema_get(julea_db_schema_space_header, batch, &error))
+				{
+					j_goto_error();
+				}
+
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
 			}
 			else
 			{
@@ -182,6 +203,27 @@ H5VL_julea_db_space_init(hid_t vipl_id)
 				}
 
 				if (!j_db_schema_create(julea_db_schema_space, batch, &error))
+				{
+					j_goto_error();
+				}
+
+				if (!j_batch_execute(batch))
+				{
+					j_goto_error();
+				}
+
+				if (julea_db_schema_space)
+				{
+					j_db_schema_unref(julea_db_schema_space);
+				}
+
+				if (!(julea_db_schema_space = j_db_schema_new(JULEA_HDF5_DB_NAMESPACE, "space", NULL)))
+				{
+					j_goto_error();
+				}
+
+				// FIXME Use same key type for every db backend to remove get for every new schema.
+				if (!j_db_schema_get(julea_db_schema_space, batch, &error))
 				{
 					j_goto_error();
 				}


### PR DESCRIPTION
Just added a `get` for each created schema after the batch is executed.