### PR TITLE
configurable port

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $ julea-config --user \
   --object-backend=posix --object-component=server --object-path="/tmp/julea-$(id -u)/posix" \
   --kv-backend=lmdb --kv-component=server --kv-path="/tmp/julea-$(id -u)/lmdb" \
   --db-backend=sqlite --db-component=server --db-path="/tmp/julea-$(id -u)/sqlite"
+  --user-id="$(id --user)"
 ```
 
 You can check whether JULEA works by executing the integrated test suite.

--- a/include/core/jconfiguration.h
+++ b/include/core/jconfiguration.h
@@ -111,6 +111,9 @@ guint64 j_configuration_get_max_operation_size(JConfiguration*);
 guint32 j_configuration_get_max_connections(JConfiguration*);
 guint64 j_configuration_get_stripe_size(JConfiguration*);
 
+/// network port to communicate
+guint16 j_configuration_get_port(JConfiguration*);
+
 G_END_DECLS
 
 /**

--- a/lib/core/jconfiguration.c
+++ b/lib/core/jconfiguration.c
@@ -142,6 +142,7 @@ struct JConfiguration
 	guint64 max_operation_size;
 	guint32 max_connections;
 	guint64 stripe_size;
+	guint16 network_port;
 
 	/**
 	 * The reference count.
@@ -281,10 +282,12 @@ j_configuration_new_for_data(GKeyFile* key_file)
 	guint64 max_operation_size;
 	guint32 max_connections;
 	guint64 stripe_size;
+	guint64 network_port;
 
 	g_return_val_if_fail(key_file != NULL, FALSE);
 
 	max_operation_size = g_key_file_get_uint64(key_file, "core", "max-operation-size", NULL);
+	network_port = g_key_file_get_uint64(key_file, "core", "port", NULL);
 	max_connections = g_key_file_get_integer(key_file, "clients", "max-connections", NULL);
 	stripe_size = g_key_file_get_uint64(key_file, "clients", "stripe-size", NULL);
 	servers_object = g_key_file_get_string_list(key_file, "servers", "object", NULL, NULL);
@@ -311,7 +314,8 @@ j_configuration_new_for_data(GKeyFile* key_file)
 	    || kv_path == NULL
 	    || db_backend == NULL
 	    || db_component == NULL
-	    || db_path == NULL)
+	    || db_path == NULL
+		|| network_port == 0 || network_port >= 0xFFFF)
 	{
 		g_free(db_backend);
 		g_free(db_component);
@@ -349,6 +353,7 @@ j_configuration_new_for_data(GKeyFile* key_file)
 	configuration->max_connections = max_connections;
 	configuration->stripe_size = stripe_size;
 	configuration->ref_count = 1;
+	configuration->network_port = network_port;
 
 	if (configuration->max_operation_size == 0)
 	{
@@ -550,6 +555,15 @@ j_configuration_get_stripe_size(JConfiguration* configuration)
 	g_return_val_if_fail(configuration != NULL, 0);
 
 	return configuration->stripe_size;
+}
+guint16
+j_configuration_get_port(JConfiguration* configuration)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_return_val_if_fail(configuration != NULL, 0);
+
+	return configuration->network_port;
 }
 
 /**

--- a/lib/core/jconnection-pool.c
+++ b/lib/core/jconnection-pool.c
@@ -197,7 +197,10 @@ j_connection_pool_pop_internal(GAsyncQueue* queue, guint* count, gchar const* se
 			guint op_count;
 
 			client = g_socket_client_new();
-			connection = g_socket_client_connect_to_host(client, server, 4711, NULL, &error);
+			connection = g_socket_client_connect_to_host(
+					client,
+					server, j_configuration_get_port(j_configuration()),
+					NULL, &error);
 
 			if (error != NULL)
 			{

--- a/meson.build
+++ b/meson.build
@@ -679,9 +679,15 @@ executable('julea-cli', julea_cli_srcs,
 	install: true,
 )
 
-executable('julea-config', 'tools/config.c',
+julea_config_srcs = files([
+  'lib/core/jcredentials.c',
+  'lib/core/jtrace.c',
+  'tools/config.c',
+])
+executable('julea-config', julea_config_srcs,
 	dependencies: common_deps,
 	include_directories: julea_incs,
+	c_args: ['-DJULEA_COMPILATION'],
 	install: true,
 )
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -194,7 +194,7 @@ setup_clean ()
 	do
 		host="$(get_host "${server}")"
 		port="$(get_port "${server}")"
-		test -n "${port}" || port='4711'
+		test -n "${port}" || port='<TODO: correct port>'
 		backend_path="$(printf '%s' "${OBJECT_PATH}" | sed "s/{PORT}/${port}/")"
 
 		if test "${host}" = "${HOSTNAME}"
@@ -210,7 +210,7 @@ setup_clean ()
 	do
 		host="$(get_host "${server}")"
 		port="$(get_port "${server}")"
-		test -n "${port}" || port='4711'
+		test -n "${port}" || port='<TODO: correct port>'
 		backend_path="$(printf '%s' "${KV_PATH}" | sed "s/{PORT}/${port}/")"
 
 		if test "${host}" = "${HOSTNAME}"
@@ -226,7 +226,7 @@ setup_clean ()
 	do
 		host="$(get_host "${server}")"
 		port="$(get_port "${server}")"
-		test -n "${port}" || port='4711'
+		test -n "${port}" || port='<TODO: correct port>'
 		backend_path="$(printf '%s' "${DB_PATH}" | sed "s/{PORT}/${port}/")"
 
 		if test "${host}" = "${HOSTNAME}"

--- a/server/server.c
+++ b/server/server.c
@@ -183,7 +183,9 @@ jd_is_server_for_backend(gchar const* host, gint port, JBackendType backend_type
 		guint16 addr_port;
 
 		server = j_configuration_get_server(jd_configuration, backend_type, i);
-		address = G_NETWORK_ADDRESS(g_network_address_parse(server, 4711, NULL));
+		address = G_NETWORK_ADDRESS(g_network_address_parse(
+					server, j_configuration_get_port(jd_configuration),
+					NULL));
 
 		addr_server = g_network_address_get_hostname(address);
 		addr_port = g_network_address_get_port(address);
@@ -204,7 +206,7 @@ main(int argc, char** argv)
 
 	gboolean opt_daemon = FALSE;
 	g_autofree gchar* opt_host = NULL;
-	gint opt_port = 4711;
+	gint opt_port = 0;
 
 	JTrace* trace;
 	GError* error = NULL;
@@ -229,7 +231,7 @@ main(int argc, char** argv)
 	GOptionEntry entries[] = {
 		{ "daemon", 0, 0, G_OPTION_ARG_NONE, &opt_daemon, "Run as daemon", NULL },
 		{ "host", 0, 0, G_OPTION_ARG_STRING, &opt_host, "Override host name", "hostname" },
-		{ "port", 0, 0, G_OPTION_ARG_INT, &opt_port, "Port to use", "4711" },
+		{ "port", 0, 0, G_OPTION_ARG_INT, &opt_port, "Port to use", "0" },
 		{ NULL, 0, 0, 0, NULL, NULL, NULL }
 	};
 
@@ -266,6 +268,16 @@ main(int argc, char** argv)
 	socket_service = g_threaded_socket_service_new(-1);
 	g_socket_listener_set_backlog(G_SOCKET_LISTENER(socket_service), 128);
 
+	jd_configuration = j_configuration_new();
+	if(!jd_configuration) {
+		g_warning("Failed to load configuration!");
+		return 1;
+	}
+
+	if(opt_port == 0) {
+		opt_port = j_configuration_get_port(jd_configuration);
+	}
+
 	while (TRUE)
 	{
 		if (!g_socket_listener_add_inet_port(G_SOCKET_LISTENER(socket_service), opt_port, NULL, &error))
@@ -296,8 +308,6 @@ main(int argc, char** argv)
 	j_trace_init("julea-server");
 
 	trace = j_trace_enter(G_STRFUNC, NULL);
-
-	jd_configuration = j_configuration_new();
 
 	if (jd_configuration == NULL)
 	{

--- a/test/core/configuration.c
+++ b/test/core/configuration.c
@@ -46,6 +46,7 @@ test_configuration_new_for_data(void)
 	gchar const* servers[] = { "localhost", NULL };
 
 	key_file = g_key_file_new();
+	g_key_file_set_uint64(key_file, "core", "port", 4700);
 	g_key_file_set_string_list(key_file, "servers", "object", servers, 1);
 	g_key_file_set_string_list(key_file, "servers", "kv", servers, 1);
 	g_key_file_set_string_list(key_file, "servers", "db", servers, 1);
@@ -76,6 +77,7 @@ test_configuration_get(void)
 	gchar const* db_servers[] = { "localhost", "host.local", NULL };
 
 	key_file = g_key_file_new();
+	g_key_file_set_uint64(key_file, "core", "port", 4700);
 	g_key_file_set_string_list(key_file, "servers", "object", object_servers, 2);
 	g_key_file_set_string_list(key_file, "servers", "kv", kv_servers, 1);
 	g_key_file_set_string_list(key_file, "servers", "db", db_servers, 2);

--- a/test/core/distribution.c
+++ b/test/core/distribution.c
@@ -33,6 +33,7 @@ test_distribution_fixture_setup(JConfiguration** configuration, gconstpointer da
 	(void)data;
 
 	key_file = g_key_file_new();
+	g_key_file_set_uint64(key_file, "core", "port", 4700);
 	g_key_file_set_string_list(key_file, "servers", "object", servers, 2);
 	g_key_file_set_string_list(key_file, "servers", "kv", servers, 2);
 	g_key_file_set_string_list(key_file, "servers", "db", servers, 2);

--- a/tools/config.c
+++ b/tools/config.c
@@ -155,7 +155,7 @@ main(gint argc, gchar** argv)
 		{ "system", 0, 0, G_OPTION_ARG_NONE, &opt_system, "Write system configuration", NULL },
 		{ "read", 0, 0, G_OPTION_ARG_NONE, &opt_read, "Read configuration", NULL },
 		{ "name", 0, 0, G_OPTION_ARG_STRING, &opt_name, "Configuration name", "julea" },
-		{ "port", 0, 0, G_OPTION_ARG_INT64, &opt_network_port, "Network communication port", "4000 + user_id%100"},
+		{ "port", 0, 0, G_OPTION_ARG_INT64, &opt_network_port, "Network communication port", "4000 + user-id%100"},
 		{ "user-id", 0, 0, G_OPTION_ARG_INT64, &opt_user_id, "User Id used to determined communication port", NULL},
 		{ "object-servers", 0, 0, G_OPTION_ARG_STRING, &opt_servers_object, "Object servers to use", "host1,host2:port" },
 		{ "kv-servers", 0, 0, G_OPTION_ARG_STRING, &opt_servers_kv, "Key-value servers to use", "host1,host2:port" },


### PR DESCRIPTION
Add `uint16 core:port` option in config to set port for network connection.

Add option to julea-config tool: `--port` to explicit set communication port.
If not explicit stated, the value will be `4000+(<user-id>%1000)`, the user id
is fetched with `JCredentials`

