### PR TITLE
Add hdf5 test cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,14 +290,14 @@ jobs:
           . scripts/environment.sh
           ./scripts/setup.sh start
           export HDF5_VOL_CONNECTOR=julea-kv
-          ./scripts/test.sh -p /hdf5
+          ./scripts/test.sh -r /hdf5
           sleep 10
-          ./scripts/test.sh -p /hdf5
+          ./scripts/test.sh -r /hdf5
           sleep 10
           export HDF5_VOL_CONNECTOR=julea-db
-          ./scripts/test.sh -p /hdf5
+          ./scripts/test.sh -r /hdf5
           sleep 10
-          ./scripts/test.sh -p /hdf5
+          ./scripts/test.sh -r /hdf5
           ./scripts/setup.sh stop
   doxygen:
     name: Doxygen

--- a/meson.build
+++ b/meson.build
@@ -520,6 +520,8 @@ julea_test_srcs = files([
 	'test/hdf5/hdf.c',
 	'test/hdf5/hdf-helper.c',
 	'test/hdf5/hdf-datatype.c',
+	'test/hdf5/hdf-dataset.c',
+	'test/hdf5/hdf-file.c',
 	'test/item/collection.c',
 	'test/item/collection-iterator.c',
 	'test/item/item.c',

--- a/meson.build
+++ b/meson.build
@@ -522,6 +522,7 @@ julea_test_srcs = files([
 	'test/hdf5/hdf-datatype.c',
 	'test/hdf5/hdf-dataset.c',
 	'test/hdf5/hdf-file.c',
+	'test/hdf5/hdf-group-link.c',
 	'test/item/collection.c',
 	'test/item/collection-iterator.c',
 	'test/item/item.c',

--- a/meson.build
+++ b/meson.build
@@ -518,6 +518,8 @@ julea_test_srcs = files([
 	'test/core/semantics.c',
 	'test/db/db.c',
 	'test/hdf5/hdf.c',
+	'test/hdf5/hdf-helper.c',
+	'test/hdf5/hdf-datatype.c',
 	'test/item/collection.c',
 	'test/item/collection-iterator.c',
 	'test/item/item.c',

--- a/meson.build
+++ b/meson.build
@@ -523,6 +523,7 @@ julea_test_srcs = files([
 	'test/hdf5/hdf-dataset.c',
 	'test/hdf5/hdf-file.c',
 	'test/hdf5/hdf-group-link.c',
+	'test/hdf5/hdf-attribute.c',
 	'test/item/collection.c',
 	'test/item/collection-iterator.c',
 	'test/item/item.c',

--- a/test/hdf5/hdf-attribute.c
+++ b/test/hdf5/hdf-attribute.c
@@ -1,0 +1,268 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2018-2019 Johannes Coym
+ * Copyright (C) 2019-2021 Michael Kuhn
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#include <julea-config.h>
+
+#include <glib.h>
+
+#include <julea.h>
+
+#include "test.h"
+
+#ifdef HAVE_HDF5
+
+#include <julea-hdf5.h>
+
+#include <hdf5.h>
+
+#include "hdf-helper.h"
+
+static void
+create_write_read_delete(hid_t loc, H5S_class_t space_type, gchar const *name, hsize_t name_len, hid_t data_type, hsize_t rank, hsize_t* dims, hsize_t len, void* data)
+{
+    hid_t space, attribute, error;
+    gboolean same = true;
+    g_autofree gchar* buf = g_malloc(len);
+    g_autofree gchar* name_buf = g_malloc(name_len);
+
+    if(space_type == H5S_SCALAR)
+    {
+        space = H5Screate(H5S_SCALAR);
+        g_assert_cmpint(space, !=, H5I_INVALID_HID);
+    }
+    else
+    {
+        space = H5Screate_simple(rank, dims, dims);
+        g_assert_cmpint(space, !=, H5I_INVALID_HID);
+    }
+
+    attribute = H5Acreate(loc, name, data_type, space, H5P_DEFAULT, H5P_DEFAULT);
+    g_assert_cmpint(attribute, !=, H5I_INVALID_HID);
+
+    error = H5Sclose(space);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Awrite(attribute, data_type, data);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Aclose(attribute);
+    g_assert_cmpint(error, >=, 0);
+
+    attribute = H5Aopen(loc, name, H5P_DEFAULT);
+    g_assert_cmpint(attribute, !=, H5I_INVALID_HID);
+
+    error = H5Aread(attribute, data_type, buf);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Aget_name(attribute, name_len, name_buf);
+    g_assert_cmpint(error, >=, 0);
+    g_assert_cmpstr(name, ==, name_buf);
+
+    error = H5Aclose(attribute);
+    g_assert_cmpint(error, >=, 0);
+
+    for(hsize_t i = 0; i < len; ++i)
+    {
+        same = same && buf[i] == ((gchar*)data)[i];
+    }
+    g_assert_true(same);
+
+    error = H5Adelete(loc, name);
+    g_assert_cmpint(error, >=, 0);
+
+    attribute = H5Aopen(loc, name, H5P_DEFAULT);
+    g_assert_cmpint(attribute, ==, H5I_INVALID_HID);
+}
+
+static void
+test_hdf_attribute_group(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hsize_t dims[] = {2, 2};
+    const gchar name1[] = "attr_name";
+    const gchar name2[] = "attr_name2";
+    int data[] = {42, 43, 44, 45};
+    int sdata = 42;
+
+	(void) udata;
+
+    // using file will attach to root group
+    create_write_read_delete(file, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
+    create_write_read_delete(file, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4*sizeof(int), (void*)data);
+}
+
+static void
+test_hdf_attribute_set(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hsize_t dims[] = {2, 2};
+	hid_t space, set;
+	hsize_t set_dims[] = {12,12,12};
+    const gchar name1[] = "attr_name";
+    const gchar name2[] = "attr_name2";
+    int data[] = {42, 43, 44, 45};
+    int sdata = 42;
+    herr_t error;
+
+	(void) udata;
+
+	space = H5Screate_simple(3, set_dims, set_dims);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	set = H5Dcreate(file, "set", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(set, !=, H5I_INVALID_HID);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
+
+    create_write_read_delete(set, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
+    create_write_read_delete(set, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4*sizeof(int), (void*)data);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_attribute_type(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+    hid_t array_type;
+	hsize_t dims[] = {2, 2};
+    const gchar name1[] = "attr_name";
+    const gchar name2[] = "attr_name2";
+    hsize_t dim = 4;
+    int data[] = {42, 43, 44, 45};
+    int sdata = 42;
+    herr_t error;
+
+	(void) udata;
+
+    array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
+    g_assert_cmpint(array_type, >=, 0);
+
+    // commit type (e.g. save it to file)
+    error = H5Tcommit2(file, "/test_dtype", array_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Tclose(array_type);
+    g_assert_cmpint(error, >=, 0);
+
+    array_type = H5Topen(file, "test_dtype", H5P_DEFAULT);
+    g_assert_cmpint(array_type, !=, H5I_INVALID_HID);
+
+    // using file will attach to root group
+    create_write_read_delete(array_type, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
+    create_write_read_delete(array_type, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4*sizeof(int), (void*)data);
+
+    error = H5Tclose(array_type);
+    g_assert_cmpint(error, >=, 0);
+
+}
+
+static void
+test_hdf_attribute_invalid_object(void)
+{
+	hid_t error, attribute, space;
+    hsize_t rank = 2;
+    hsize_t dims[] = {2,2};
+    
+    space = H5Screate_simple(rank, dims, dims);
+    g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+    attribute = H5Acreate(H5I_INVALID_HID, "name", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+    g_assert_cmpint(attribute, ==, H5I_INVALID_HID);
+
+    error = H5Sclose(space);
+    g_assert_cmpint(error, >=, 0);
+}
+
+static herr_t
+it_op(hid_t attr, const char *name, const H5A_info_t *info, void *op_data)
+{
+	int* count = (int*)op_data;
+	(void) info;
+	(void) attr;
+	(void) name;
+
+	++(*count);
+	return 0;
+}
+
+static void
+test_hdf_attribute_iterate(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+    hid_t space, a1, a2, a3, error;
+	hsize_t dims[] = {2,2};
+    hsize_t count = 0;
+
+	(void) udata;
+
+    space = H5Screate_simple(2, dims, dims);
+    g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+    a1 = H5Acreate(file, "a1", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+    g_assert_cmpint(a1, !=, H5I_INVALID_HID);
+
+    a2 = H5Acreate(file, "a2", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+    g_assert_cmpint(a2, !=, H5I_INVALID_HID);
+
+    a3 = H5Acreate(file, "a3", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+    g_assert_cmpint(a3, !=, H5I_INVALID_HID);
+
+    error = H5Sclose(space);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Aclose(a1);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Aclose(a2);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Aclose(a3);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Aiterate(file, H5_INDEX_NAME, H5_ITER_NATIVE, NULL, it_op, &count);
+    g_assert_cmpint(error, >=, 0);
+    g_assert_cmpint(count, ==, 3);
+}
+
+#endif
+
+void
+test_hdf_attribute(void)
+{
+#ifdef HAVE_HDF5
+	if (g_getenv("HDF5_VOL_CONNECTOR") == NULL)
+	{
+		// Running tests only makes sense for our HDF5 clients
+		return;
+	}
+	g_test_add("/hdf5/attribute-group", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_group, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/attribute-set", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_set, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/attribute-type", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_type, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/attribute-iterate", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_iterate, j_test_hdf_file_fixture_teardown);
+	g_test_add_func("/hdf5/attribut-create_invalid", test_hdf_attribute_invalid_object);
+	
+#endif
+}

--- a/test/hdf5/hdf-attribute.c
+++ b/test/hdf5/hdf-attribute.c
@@ -1,7 +1,6 @@
 /*
  * JULEA - Flexible storage framework
- * Copyright (C) 2018-2019 Johannes Coym
- * Copyright (C) 2019-2021 Michael Kuhn
+ * Copyright (C) 2021 Timm Leon Erxleben
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/test/hdf5/hdf-attribute.c
+++ b/test/hdf5/hdf-attribute.c
@@ -38,93 +38,93 @@
 #include "hdf-helper.h"
 
 static void
-create_write_read_delete(hid_t loc, H5S_class_t space_type, gchar const *name, hsize_t name_len, hid_t data_type, hsize_t rank, hsize_t* dims, hsize_t len, void* data)
+create_write_read_delete(hid_t loc, H5S_class_t space_type, gchar const* name, hsize_t name_len, hid_t data_type, hsize_t rank, hsize_t* dims, hsize_t len, void* data)
 {
-    hid_t space, attribute, error;
-    gboolean same = true;
-    g_autofree gchar* buf = g_malloc(len);
-    g_autofree gchar* name_buf = g_malloc(name_len);
+	hid_t space, attribute, error;
+	gboolean same = true;
+	g_autofree gchar* buf = g_malloc(len);
+	g_autofree gchar* name_buf = g_malloc(name_len);
 
-    if(space_type == H5S_SCALAR)
-    {
-        space = H5Screate(H5S_SCALAR);
-        g_assert_cmpint(space, !=, H5I_INVALID_HID);
-    }
-    else
-    {
-        space = H5Screate_simple(rank, dims, dims);
-        g_assert_cmpint(space, !=, H5I_INVALID_HID);
-    }
+	if (space_type == H5S_SCALAR)
+	{
+		space = H5Screate(H5S_SCALAR);
+		g_assert_cmpint(space, !=, H5I_INVALID_HID);
+	}
+	else
+	{
+		space = H5Screate_simple(rank, dims, dims);
+		g_assert_cmpint(space, !=, H5I_INVALID_HID);
+	}
 
-    attribute = H5Acreate(loc, name, data_type, space, H5P_DEFAULT, H5P_DEFAULT);
-    g_assert_cmpint(attribute, !=, H5I_INVALID_HID);
+	attribute = H5Acreate(loc, name, data_type, space, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(attribute, !=, H5I_INVALID_HID);
 
-    error = H5Sclose(space);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
 
-    error = H5Awrite(attribute, data_type, data);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Awrite(attribute, data_type, data);
+	g_assert_cmpint(error, >=, 0);
 
-    error = H5Aclose(attribute);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Aclose(attribute);
+	g_assert_cmpint(error, >=, 0);
 
-    attribute = H5Aopen(loc, name, H5P_DEFAULT);
-    g_assert_cmpint(attribute, !=, H5I_INVALID_HID);
+	attribute = H5Aopen(loc, name, H5P_DEFAULT);
+	g_assert_cmpint(attribute, !=, H5I_INVALID_HID);
 
-    error = H5Aread(attribute, data_type, buf);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Aread(attribute, data_type, buf);
+	g_assert_cmpint(error, >=, 0);
 
-    error = H5Aget_name(attribute, name_len, name_buf);
-    g_assert_cmpint(error, >=, 0);
-    g_assert_cmpstr(name, ==, name_buf);
+	error = H5Aget_name(attribute, name_len, name_buf);
+	g_assert_cmpint(error, >=, 0);
+	g_assert_cmpstr(name, ==, name_buf);
 
-    error = H5Aclose(attribute);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Aclose(attribute);
+	g_assert_cmpint(error, >=, 0);
 
-    for(hsize_t i = 0; i < len; ++i)
-    {
-        same = same && buf[i] == ((gchar*)data)[i];
-    }
-    g_assert_true(same);
+	for (hsize_t i = 0; i < len; ++i)
+	{
+		same = same && buf[i] == ((gchar*)data)[i];
+	}
+	g_assert_true(same);
 
-    error = H5Adelete(loc, name);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Adelete(loc, name);
+	g_assert_cmpint(error, >=, 0);
 
-    attribute = H5Aopen(loc, name, H5P_DEFAULT);
-    g_assert_cmpint(attribute, ==, H5I_INVALID_HID);
+	attribute = H5Aopen(loc, name, H5P_DEFAULT);
+	g_assert_cmpint(attribute, ==, H5I_INVALID_HID);
 }
 
 static void
 test_hdf_attribute_group(hid_t* file_fixture, gconstpointer udata)
 {
 	hid_t file = *file_fixture;
-	hsize_t dims[] = {2, 2};
-    const gchar name1[] = "attr_name";
-    const gchar name2[] = "attr_name2";
-    int data[] = {42, 43, 44, 45};
-    int sdata = 42;
+	hsize_t dims[] = { 2, 2 };
+	const gchar name1[] = "attr_name";
+	const gchar name2[] = "attr_name2";
+	int data[] = { 42, 43, 44, 45 };
+	int sdata = 42;
 
-	(void) udata;
+	(void)udata;
 
-    // using file will attach to root group
-    create_write_read_delete(file, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
-    create_write_read_delete(file, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4*sizeof(int), (void*)data);
+	// using file will attach to root group
+	create_write_read_delete(file, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
+	create_write_read_delete(file, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4 * sizeof(int), (void*)data);
 }
 
 static void
 test_hdf_attribute_set(hid_t* file_fixture, gconstpointer udata)
 {
 	hid_t file = *file_fixture;
-	hsize_t dims[] = {2, 2};
+	hsize_t dims[] = { 2, 2 };
 	hid_t space, set;
-	hsize_t set_dims[] = {12,12,12};
-    const gchar name1[] = "attr_name";
-    const gchar name2[] = "attr_name2";
-    int data[] = {42, 43, 44, 45};
-    int sdata = 42;
-    herr_t error;
+	hsize_t set_dims[] = { 12, 12, 12 };
+	const gchar name1[] = "attr_name";
+	const gchar name2[] = "attr_name2";
+	int data[] = { 42, 43, 44, 45 };
+	int sdata = 42;
+	herr_t error;
 
-	(void) udata;
+	(void)udata;
 
 	space = H5Screate_simple(3, set_dims, set_dims);
 	g_assert_cmpint(space, !=, H5I_INVALID_HID);
@@ -135,8 +135,8 @@ test_hdf_attribute_set(hid_t* file_fixture, gconstpointer udata)
 	error = H5Sclose(space);
 	g_assert_cmpint(error, >=, 0);
 
-    create_write_read_delete(set, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
-    create_write_read_delete(set, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4*sizeof(int), (void*)data);
+	create_write_read_delete(set, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
+	create_write_read_delete(set, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4 * sizeof(int), (void*)data);
 
 	error = H5Dclose(set);
 	g_assert_cmpint(error, >=, 0);
@@ -146,63 +146,62 @@ static void
 test_hdf_attribute_type(hid_t* file_fixture, gconstpointer udata)
 {
 	hid_t file = *file_fixture;
-    hid_t array_type;
-	hsize_t dims[] = {2, 2};
-    const gchar name1[] = "attr_name";
-    const gchar name2[] = "attr_name2";
-    hsize_t dim = 4;
-    int data[] = {42, 43, 44, 45};
-    int sdata = 42;
-    herr_t error;
+	hid_t array_type;
+	hsize_t dims[] = { 2, 2 };
+	const gchar name1[] = "attr_name";
+	const gchar name2[] = "attr_name2";
+	hsize_t dim = 4;
+	int data[] = { 42, 43, 44, 45 };
+	int sdata = 42;
+	herr_t error;
 
-	(void) udata;
+	(void)udata;
 
-    array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
-    g_assert_cmpint(array_type, >=, 0);
+	array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
+	g_assert_cmpint(array_type, >=, 0);
 
-    // commit type (e.g. save it to file)
-    error = H5Tcommit2(file, "/test_dtype", array_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    g_assert_cmpint(error, >=, 0);
+	// commit type (e.g. save it to file)
+	error = H5Tcommit2(file, "/test_dtype", array_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
 
-    error = H5Tclose(array_type);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Tclose(array_type);
+	g_assert_cmpint(error, >=, 0);
 
-    array_type = H5Topen(file, "test_dtype", H5P_DEFAULT);
-    g_assert_cmpint(array_type, !=, H5I_INVALID_HID);
+	array_type = H5Topen(file, "test_dtype", H5P_DEFAULT);
+	g_assert_cmpint(array_type, !=, H5I_INVALID_HID);
 
-    // using file will attach to root group
-    create_write_read_delete(array_type, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
-    create_write_read_delete(array_type, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4*sizeof(int), (void*)data);
+	// using file will attach to root group
+	create_write_read_delete(array_type, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
+	create_write_read_delete(array_type, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4 * sizeof(int), (void*)data);
 
-    error = H5Tclose(array_type);
-    g_assert_cmpint(error, >=, 0);
-
+	error = H5Tclose(array_type);
+	g_assert_cmpint(error, >=, 0);
 }
 
 static void
 test_hdf_attribute_invalid_object(void)
 {
 	hid_t error, attribute, space;
-    hsize_t rank = 2;
-    hsize_t dims[] = {2,2};
-    
-    space = H5Screate_simple(rank, dims, dims);
-    g_assert_cmpint(space, !=, H5I_INVALID_HID);
+	hsize_t rank = 2;
+	hsize_t dims[] = { 2, 2 };
 
-    attribute = H5Acreate(H5I_INVALID_HID, "name", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
-    g_assert_cmpint(attribute, ==, H5I_INVALID_HID);
+	space = H5Screate_simple(rank, dims, dims);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
 
-    error = H5Sclose(space);
-    g_assert_cmpint(error, >=, 0);
+	attribute = H5Acreate(H5I_INVALID_HID, "name", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(attribute, ==, H5I_INVALID_HID);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
 }
 
 static herr_t
-it_op(hid_t attr, const char *name, const H5A_info_t *info, void *op_data)
+it_op(hid_t attr, const char* name, const H5A_info_t* info, void* op_data)
 {
 	int* count = (int*)op_data;
-	(void) info;
-	(void) attr;
-	(void) name;
+	(void)info;
+	(void)attr;
+	(void)name;
 
 	++(*count);
 	return 0;
@@ -212,39 +211,39 @@ static void
 test_hdf_attribute_iterate(hid_t* file_fixture, gconstpointer udata)
 {
 	hid_t file = *file_fixture;
-    hid_t space, a1, a2, a3, error;
-	hsize_t dims[] = {2,2};
-    hsize_t count = 0;
+	hid_t space, a1, a2, a3, error;
+	hsize_t dims[] = { 2, 2 };
+	hsize_t count = 0;
 
-	(void) udata;
+	(void)udata;
 
-    space = H5Screate_simple(2, dims, dims);
-    g_assert_cmpint(space, !=, H5I_INVALID_HID);
+	space = H5Screate_simple(2, dims, dims);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
 
-    a1 = H5Acreate(file, "a1", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
-    g_assert_cmpint(a1, !=, H5I_INVALID_HID);
+	a1 = H5Acreate(file, "a1", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(a1, !=, H5I_INVALID_HID);
 
-    a2 = H5Acreate(file, "a2", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
-    g_assert_cmpint(a2, !=, H5I_INVALID_HID);
+	a2 = H5Acreate(file, "a2", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(a2, !=, H5I_INVALID_HID);
 
-    a3 = H5Acreate(file, "a3", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
-    g_assert_cmpint(a3, !=, H5I_INVALID_HID);
+	a3 = H5Acreate(file, "a3", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(a3, !=, H5I_INVALID_HID);
 
-    error = H5Sclose(space);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
 
-    error = H5Aclose(a1);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Aclose(a1);
+	g_assert_cmpint(error, >=, 0);
 
-    error = H5Aclose(a2);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Aclose(a2);
+	g_assert_cmpint(error, >=, 0);
 
-    error = H5Aclose(a3);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Aclose(a3);
+	g_assert_cmpint(error, >=, 0);
 
-    error = H5Aiterate(file, H5_INDEX_NAME, H5_ITER_NATIVE, NULL, it_op, &count);
-    g_assert_cmpint(error, >=, 0);
-    g_assert_cmpint(count, ==, 3);
+	error = H5Aiterate(file, H5_INDEX_NAME, H5_ITER_NATIVE, NULL, it_op, &count);
+	g_assert_cmpint(error, >=, 0);
+	g_assert_cmpint(count, ==, 3);
 }
 
 #endif
@@ -263,6 +262,6 @@ test_hdf_attribute(void)
 	g_test_add("/hdf5/attribute-type", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_type, j_test_hdf_file_fixture_teardown);
 	g_test_add("/hdf5/attribute-iterate", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_iterate, j_test_hdf_file_fixture_teardown);
 	g_test_add_func("/hdf5/attribut-create_invalid", test_hdf_attribute_invalid_object);
-	
+
 #endif
 }

--- a/test/hdf5/hdf-attribute.c
+++ b/test/hdf5/hdf-attribute.c
@@ -112,6 +112,8 @@ test_hdf_attribute_group(hid_t* file_fixture, gconstpointer udata)
 	create_write_read_delete(file, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4 * sizeof(int), (void*)data);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -147,6 +149,8 @@ test_hdf_attribute_set(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -179,7 +183,6 @@ test_hdf_attribute_type(hid_t* file_fixture, gconstpointer udata)
 	array_type = H5Topen(file, "test_dtype", H5P_DEFAULT);
 	g_assert_cmpint(array_type, !=, H5I_INVALID_HID);
 
-	// using file will attach to root group
 	create_write_read_delete(array_type, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
 	create_write_read_delete(array_type, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4 * sizeof(int), (void*)data);
 
@@ -187,6 +190,8 @@ test_hdf_attribute_type(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -263,6 +268,8 @@ test_hdf_attribute_iterate(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(count, ==, 3);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 #endif

--- a/test/hdf5/hdf-attribute.c
+++ b/test/hdf5/hdf-attribute.c
@@ -106,9 +106,13 @@ test_hdf_attribute_group(hid_t* file_fixture, gconstpointer udata)
 
 	(void)udata;
 
+	J_TEST_TRAP_START;
+
 	// using file will attach to root group
 	create_write_read_delete(file, H5S_SCALAR, name1, sizeof(name1), H5T_NATIVE_INT, 0, NULL, sizeof(int), (void*)&sdata);
 	create_write_read_delete(file, H5S_SIMPLE, name2, sizeof(name2), H5T_NATIVE_INT, 2, dims, 4 * sizeof(int), (void*)data);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -126,6 +130,8 @@ test_hdf_attribute_set(hid_t* file_fixture, gconstpointer udata)
 
 	(void)udata;
 
+	J_TEST_TRAP_START;
+
 	space = H5Screate_simple(3, set_dims, set_dims);
 	g_assert_cmpint(space, !=, H5I_INVALID_HID);
 
@@ -140,6 +146,8 @@ test_hdf_attribute_set(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Dclose(set);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -156,6 +164,8 @@ test_hdf_attribute_type(hid_t* file_fixture, gconstpointer udata)
 	herr_t error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
 	g_assert_cmpint(array_type, >=, 0);
@@ -176,6 +186,8 @@ test_hdf_attribute_type(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Tclose(array_type);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -185,6 +197,8 @@ test_hdf_attribute_invalid_object(void)
 	hsize_t rank = 2;
 	hsize_t dims[] = { 2, 2 };
 
+	J_TEST_TRAP_START;
+
 	space = H5Screate_simple(rank, dims, dims);
 	g_assert_cmpint(space, !=, H5I_INVALID_HID);
 
@@ -193,6 +207,8 @@ test_hdf_attribute_invalid_object(void)
 
 	error = H5Sclose(space);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static herr_t
@@ -216,6 +232,8 @@ test_hdf_attribute_iterate(hid_t* file_fixture, gconstpointer udata)
 	hsize_t count = 0;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	space = H5Screate_simple(2, dims, dims);
 	g_assert_cmpint(space, !=, H5I_INVALID_HID);
@@ -244,6 +262,8 @@ test_hdf_attribute_iterate(hid_t* file_fixture, gconstpointer udata)
 	error = H5Aiterate(file, H5_INDEX_NAME, H5_ITER_NATIVE, NULL, it_op, &count);
 	g_assert_cmpint(error, >=, 0);
 	g_assert_cmpint(count, ==, 3);
+
+	J_TEST_TRAP_END;
 }
 
 #endif
@@ -257,11 +277,11 @@ test_hdf_attribute(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
-	g_test_add("/hdf5/attribute-group", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_group, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/attribute-set", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_set, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/attribute-type", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_type, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/attribute-iterate", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_iterate, j_test_hdf_file_fixture_teardown);
-	g_test_add_func("/hdf5/attribut-create_invalid", test_hdf_attribute_invalid_object);
+	g_test_add("/hdf5/attribute/group", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_group, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/attribute/set", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_set, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/attribute/type", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_type, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/attribute/iterate", hid_t, "attribute_file.h5", j_test_hdf_file_fixture_setup, test_hdf_attribute_iterate, j_test_hdf_file_fixture_teardown);
+	g_test_add_func("/hdf5/attribute/create_invalid", test_hdf_attribute_invalid_object);
 
 #endif
 }

--- a/test/hdf5/hdf-dataset.c
+++ b/test/hdf5/hdf-dataset.c
@@ -1,7 +1,6 @@
 /*
  * JULEA - Flexible storage framework
- * Copyright (C) 2018-2019 Johannes Coym
- * Copyright (C) 2019-2021 Michael Kuhn
+ * Copyright (C) 2021 Timm Leon Erxleben
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/test/hdf5/hdf-dataset.c
+++ b/test/hdf5/hdf-dataset.c
@@ -109,6 +109,8 @@ test_hdf_dataset_create_delete_open_close(hid_t* file_fixture, gconstpointer uda
 	create_open_close_delete(file, H5S_SIMPLE, "chunked", H5T_NATIVE_INT, 3, dims, unlimitted_dim, chunk_size);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -167,6 +169,8 @@ test_hdf_dataset_extend(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -209,6 +213,8 @@ test_hdf_dataset_invalid_extend(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -333,6 +339,8 @@ test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -457,6 +465,8 @@ test_hdf_dataset_write_read_single(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 #endif

--- a/test/hdf5/hdf-dataset.c
+++ b/test/hdf5/hdf-dataset.c
@@ -1,0 +1,447 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2018-2019 Johannes Coym
+ * Copyright (C) 2019-2021 Michael Kuhn
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#include <julea-config.h>
+
+#include <glib.h>
+
+#include <julea.h>
+
+#include "test.h"
+
+#ifdef HAVE_HDF5
+
+#include <julea-hdf5.h>
+
+#include <hdf5.h>
+
+#include "hdf-helper.h"
+
+static void
+create_open_close_delete(hid_t file, H5S_class_t space_type, gchar const *name, H5T_class_t data_type, hsize_t rank, hsize_t* dims, hsize_t* maxdims, hsize_t* chunk_size)
+{
+	hid_t space, set, dcpl;
+	herr_t error;
+
+	if(rank == 0)
+	{
+		space = H5Screate(space_type);
+	}
+	else
+	{
+		space = H5Screate_simple(rank, dims, maxdims);
+	}
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	dcpl = H5Pcopy(H5P_DATASET_CREATE_DEFAULT);
+	g_assert_cmpint(dcpl, !=, H5I_INVALID_HID);
+
+	if(chunk_size != NULL)
+	{
+		error = H5Pset_chunk(dcpl, rank, chunk_size);
+		g_assert_cmpint(error, >=, 0);
+	}
+
+	set = H5Dcreate(file, name, data_type, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+	g_assert_cmpint(set, !=, H5I_INVALID_HID);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	space = H5Dopen(file, name, H5P_DEFAULT);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Ldelete(file, name, H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_dataset_create_delete_open_close(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hsize_t dims[] = {1,2,3};
+	hsize_t maxdims[] = {2,3,4};
+	hsize_t unlimitted_dim[] = {H5S_UNLIMITED, H5S_UNLIMITED, H5S_UNLIMITED};
+	hsize_t chunk_size[] = {3,3,3};
+	hsize_t zero_dim[] = {1,0,0};
+
+	(void) udata;
+
+	// null
+	create_open_close_delete(file, H5S_NULL, "null", H5T_NATIVE_INT, 0, NULL, NULL, NULL);
+	
+	// scalar
+	create_open_close_delete(file, H5S_SCALAR, "scalar", H5T_NATIVE_INT, 0, NULL, NULL, NULL);
+	
+	// simple
+	create_open_close_delete(file, H5S_SIMPLE, "simple", H5T_NATIVE_INT, 3, dims, maxdims, NULL);
+	
+	// simple zero_dim
+	create_open_close_delete(file, H5S_SIMPLE, "simple_zero", H5T_NATIVE_INT, 3, zero_dim, maxdims, NULL);
+	
+	// chunked	
+	create_open_close_delete(file, H5S_SIMPLE, "chunked", H5T_NATIVE_INT, 3, dims, unlimitted_dim, chunk_size);
+}
+
+static void
+test_hdf_dataset_extend(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t space, set, dcpl, new_space;
+	hsize_t dims[] = {1,2,3};
+	hsize_t new_dims[] = {30,40,50};
+	hsize_t unlimitted_dim[] = {H5S_UNLIMITED, H5S_UNLIMITED, H5S_UNLIMITED};
+	hsize_t chunk_size[] = {3,3,3};
+	hsize_t *loaded_dims, *loaded_maxdims;
+	int new_rank;
+	herr_t error;
+
+	(void) udata;
+
+	space = H5Screate_simple(3, dims, unlimitted_dim);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	dcpl = H5Pcopy(H5P_DATASET_CREATE_DEFAULT);
+	g_assert_cmpint(dcpl, !=, H5I_INVALID_HID);
+
+	error = H5Pset_chunk(dcpl, 3, chunk_size);
+	g_assert_cmpint(error, >=, 0);
+
+	set = H5Dcreate(file, "chunked", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+	g_assert_cmpint(set, !=, H5I_INVALID_HID);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Dset_extent(set, new_dims);
+	g_assert_cmpint(error, >=, 0);
+
+	new_space = H5Dget_space(set);
+	g_assert_cmpint(new_space, !=, H5I_INVALID_HID);
+
+	new_rank = H5Sget_simple_extent_dims(new_space, loaded_dims, loaded_maxdims);
+	g_assert_cmpint(new_rank, ==, 3);
+	g_assert_cmpint(loaded_dims[0], ==, 30);
+	g_assert_cmpint(loaded_dims[1], ==, 40);
+	g_assert_cmpint(loaded_dims[2], ==, 50);
+	g_assert_true(loaded_maxdims[0] == loaded_maxdims[1] == loaded_maxdims[2] == H5S_UNLIMITED);
+
+	free(loaded_maxdims);
+	free(loaded_dims);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Ldelete(file, "chunked", H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_dataset_invalid_extend(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t space, set, dcpl;
+	hsize_t dims[] = {1,2,3};
+	hsize_t new_dims[] = {30,40,50};
+	hsize_t max_dims[] = {3, 4, 5};
+	hsize_t chunk_size[] = {3,3,3};
+	herr_t error;
+
+	(void) udata;
+
+	space = H5Screate_simple(3, dims, max_dims);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	dcpl = H5Pcopy(H5P_DATASET_CREATE_DEFAULT);
+	g_assert_cmpint(dcpl, !=, H5I_INVALID_HID);
+
+	error = H5Pset_chunk(dcpl, 3, chunk_size);
+	g_assert_cmpint(error, >=, 0);
+
+	set = H5Dcreate(file, "chunked", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+	g_assert_cmpint(set, !=, H5I_INVALID_HID);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Dset_extent(set, new_dims);
+	g_assert_cmpint(error, <, 0);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Ldelete(file, "chunked", H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_dataset_write_read(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t space, set;
+	hsize_t rank = 2;
+	hsize_t dim[] = {1000,1000};
+	g_autofree int *data = NULL;
+	herr_t error;
+
+	(void) udata;
+
+	// create dataspace and set
+	space = H5Screate_simple(rank, dim, dim);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	set = H5Dcreate(file, "write_read_test", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(set, !=, H5I_INVALID_HID);
+
+	// generate data
+	data = g_malloc(1000000 * sizeof(int));
+	for(int i = 0; i < 999999; ++i) data[i] = i;
+
+	// write data
+	error = H5Dwrite(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
+	g_assert_cmpint(error, >=, 0);
+
+	// read data
+	error = H5Dread(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
+	g_assert_cmpint(error, >=, 0);
+
+	// check data
+	for(int i = 0; i < 999999; ++i) g_assert_cmpint(data[i], ==, i);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t space, set, hyperslab, mem_space;
+	hsize_t rank = 2;
+	hsize_t dim[] = {1000, 1000};
+	hsize_t start[] = {0, 0};
+	hsize_t stride[] = {2, 2};
+	hsize_t count[] = {500, 500};
+	g_autofree int *data = NULL;
+	g_autofree int *write_data = NULL;
+	g_autofree int *read_data = NULL;
+	herr_t error;
+
+	(void) udata;
+
+	// create dataspace and set
+	space = H5Screate_simple(rank, dim, dim);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	set = H5Dcreate(file, "write_read_test", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(set, !=, H5I_INVALID_HID);
+
+	// generate data
+	data = g_malloc(1000000 * sizeof(int));
+	for(int i = 0; i < 999999; ++i) data[i] = 9001;
+
+	// write data
+	error = H5Dwrite(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
+	g_assert_cmpint(error, >=, 0);
+
+	// overwrite every second value
+	hyperslab = H5Scopy(space);
+	g_assert_cmpint(hyperslab, !=, H5I_INVALID_HID);
+
+	error = H5Sselect_hyperslab(hyperslab, H5S_SELECT_SET, start, stride, count, NULL);
+	g_assert_cmpint(error, >=, 0);
+
+	write_data = g_malloc(250000 * sizeof(int));
+	for(int i = 0; i < 249999; ++i) write_data[i] = 42;
+
+	// space of mem data
+	mem_space = H5Screate_simple(rank, count, count);
+	g_assert_cmpint(mem_space, !=, H5I_INVALID_HID);
+
+	// scatter write
+	error = H5Dwrite(set, H5T_NATIVE_INT, mem_space, hyperslab, H5P_DEFAULT, write_data);
+	g_assert_cmpint(error, >=, 0);
+
+	// gather read
+	read_data = g_malloc(250000 * sizeof(int));
+	error = H5Dread(set, H5T_NATIVE_INT, mem_space, hyperslab, H5P_DEFAULT, read_data);
+
+	// check data
+	for(int i = 0; i < 249999; ++i) g_assert_cmpint(read_data[i], ==, 42);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Sclose(mem_space);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Sclose(hyperslab);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_dataset_write_read_chunked(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t space, set, dcpl;
+	hsize_t rank = 2;
+	hsize_t dim[] = {1000,1000};
+	hsize_t chunk_size[] = {100,100};
+	g_autofree int *data = NULL;
+	herr_t error;
+
+	(void) udata;
+
+	// create dataspace and set
+	space = H5Screate_simple(rank, dim, dim);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	dcpl = H5Pcopy(H5P_DATASET_CREATE_DEFAULT);
+	g_assert_cmpint(dcpl, !=, H5I_INVALID_HID);
+
+	error = H5Pset_chunk(dcpl, rank, chunk_size);
+	g_assert_cmpint(error, >=, 0);
+
+	set = H5Dcreate(file, "write_read_chunked_test", H5T_NATIVE_INT, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+	g_assert_cmpint(set, !=, H5I_INVALID_HID);
+
+	// generate data
+	data = g_malloc(1000000 * sizeof(int));
+	for(int i = 0; i < 999999; ++i) data[i] = i;
+
+	// write data
+	error = H5Dwrite(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
+	g_assert_cmpint(error, >=, 0);
+
+	// read data
+	error = H5Dread(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
+	g_assert_cmpint(error, >=, 0);
+
+	// check data
+	for(int i = 0; i < 999999; ++i) g_assert_cmpint(data[i], ==, i);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_dataset_write_read_single(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t space, set, elements, mem_space;
+	hsize_t rank = 2;
+	hsize_t dim[] = {1000, 1000};
+	hsize_t n = 1;
+	hsize_t coord[1][2] = {{3,3}};
+	g_autofree int *data = NULL;
+	int write = 42;
+	int read = 0;
+	herr_t error;
+
+	(void) udata;
+
+	// create dataspace and set
+	space = H5Screate_simple(rank, dim, dim);
+	g_assert_cmpint(space, !=, H5I_INVALID_HID);
+
+	set = H5Dcreate(file, "write_read_test", H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(set, !=, H5I_INVALID_HID);
+
+	// generate data
+	data = g_malloc(1000000 * sizeof(int));
+	for(int i = 0; i < 999999; ++i) data[i] = 9001;
+
+	// write data
+	error = H5Dwrite(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
+	g_assert_cmpint(error, >=, 0);
+
+	// overwrite single value at (3,3)
+	elements = H5Scopy(space);
+	g_assert_cmpint(elements, !=, H5I_INVALID_HID);
+
+	error = H5Sselect_elements(elements, H5S_SELECT_SET, n, coord);
+	g_assert_cmpint(error, >=, 0);
+
+	// space of mem data
+	mem_space = H5Screate(H5S_SCALAR);
+	g_assert_cmpint(mem_space, !=, H5I_INVALID_HID);
+
+	// scatter write
+	error = H5Dwrite(set, H5T_NATIVE_INT, mem_space, elements, H5P_DEFAULT, &write);
+	g_assert_cmpint(error, >=, 0);
+
+	// gather read
+	error = H5Dread(set, H5T_NATIVE_INT, mem_space, elements, H5P_DEFAULT, &read);
+
+	// check data
+	g_assert_cmpint(read, ==, 42);
+
+	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Sclose(space);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Sclose(mem_space);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Sclose(elements);
+	g_assert_cmpint(error, >=, 0);
+}
+
+#endif
+
+void
+test_hdf_dataset(void)
+{
+#ifdef HAVE_HDF5
+	if (g_getenv("HDF5_VOL_CONNECTOR") == NULL)
+	{
+		// Running tests only makes sense for our HDF5 clients
+		return;
+	}
+	g_test_add("/hdf5/dataset-create_delete_open_close", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_dataset_create_delete_open_close, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset-extend", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_dataset_extend, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset-invalid_extend", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_dataset_invalid_extend, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset-write_read", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/datatype-write_read_selection", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_selection, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/datatype-write_read_chunked", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_chunked, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/datatype-write_read_single", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_single, j_test_hdf_file_fixture_teardown);
+
+#endif
+}

--- a/test/hdf5/hdf-dataset.c
+++ b/test/hdf5/hdf-dataset.c
@@ -92,6 +92,8 @@ test_hdf_dataset_create_delete_open_close(hid_t* file_fixture, gconstpointer uda
 
 	(void)udata;
 
+	J_TEST_TRAP_START;
+
 	// null
 	create_open_close_delete(file, H5S_NULL, "null", H5T_NATIVE_INT, 0, NULL, NULL, NULL);
 
@@ -106,6 +108,8 @@ test_hdf_dataset_create_delete_open_close(hid_t* file_fixture, gconstpointer uda
 
 	// chunked
 	create_open_close_delete(file, H5S_SIMPLE, "chunked", H5T_NATIVE_INT, 3, dims, unlimitted_dim, chunk_size);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -123,6 +127,8 @@ test_hdf_dataset_extend(hid_t* file_fixture, gconstpointer udata)
 	herr_t error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	space = H5Screate_simple(3, dims, unlimitted_dim);
 	g_assert_cmpint(space, !=, H5I_INVALID_HID);
@@ -160,6 +166,8 @@ test_hdf_dataset_extend(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Ldelete(file, "chunked", H5P_DEFAULT);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -174,6 +182,8 @@ test_hdf_dataset_invalid_extend(hid_t* file_fixture, gconstpointer udata)
 	herr_t error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	space = H5Screate_simple(3, dims, max_dims);
 	g_assert_cmpint(space, !=, H5I_INVALID_HID);
@@ -198,6 +208,8 @@ test_hdf_dataset_invalid_extend(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Ldelete(file, "chunked", H5P_DEFAULT);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -211,6 +223,8 @@ test_hdf_dataset_write_read(hid_t* file_fixture, gconstpointer udata)
 	herr_t error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	// create dataspace and set
 	space = H5Screate_simple(rank, dim, dim);
@@ -241,6 +255,8 @@ test_hdf_dataset_write_read(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Sclose(space);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -259,6 +275,8 @@ test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
 	herr_t error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	// create dataspace and set
 	space = H5Screate_simple(rank, dim, dim);
@@ -314,6 +332,8 @@ test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Sclose(hyperslab);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -328,6 +348,8 @@ test_hdf_dataset_write_read_chunked(hid_t* file_fixture, gconstpointer udata)
 	herr_t error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	// create dataspace and set
 	space = H5Screate_simple(rank, dim, dim);
@@ -364,6 +386,8 @@ test_hdf_dataset_write_read_chunked(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Sclose(space);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -381,6 +405,8 @@ test_hdf_dataset_write_read_single(hid_t* file_fixture, gconstpointer udata)
 	herr_t error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	// create dataspace and set
 	space = H5Screate_simple(rank, dim, dim);
@@ -430,6 +456,8 @@ test_hdf_dataset_write_read_single(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Sclose(elements);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 #endif
@@ -443,13 +471,13 @@ test_hdf_dataset(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
-	g_test_add("/hdf5/dataset-create_delete_open_close", hid_t, "set_open_close.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_create_delete_open_close, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/dataset-extend", hid_t, "set_extend.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_extend, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/dataset-invalid_extend", hid_t, "set_invalid_extend.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_invalid_extend, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/dataset-write_read", hid_t, "set_write_read.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/dataset-write_read_selection", hid_t, "set_write_read_sel.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_selection, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/dataset-write_read_chunked", hid_t, "set_write_read_chunked.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_chunked, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/dataset-write_read_single", hid_t, "set_write_read_single.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_single, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset/create_delete_open_close", hid_t, "set_open_close.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_create_delete_open_close, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset/extend", hid_t, "set_extend.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_extend, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset/invalid_extend", hid_t, "set_invalid_extend.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_invalid_extend, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset/write_read", hid_t, "set_write_read.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset/write_read_selection", hid_t, "set_write_read_sel.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_selection, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset/write_read_chunked", hid_t, "set_write_read_chunked.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_chunked, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/dataset/write_read_single", hid_t, "set_write_read_single.h5", j_test_hdf_file_fixture_setup, test_hdf_dataset_write_read_single, j_test_hdf_file_fixture_teardown);
 
 #endif
 }

--- a/test/hdf5/hdf-dataset.c
+++ b/test/hdf5/hdf-dataset.c
@@ -113,12 +113,12 @@ test_hdf_dataset_extend(hid_t* file_fixture, gconstpointer udata)
 {
 	hid_t file = *file_fixture;
 	hid_t space, set, dcpl, new_space;
-	hsize_t dims[] = {1,2,3};
+	hsize_t dims[] = {12,12,12};
 	hsize_t new_dims[] = {30,40,50};
 	hsize_t unlimitted_dim[] = {H5S_UNLIMITED, H5S_UNLIMITED, H5S_UNLIMITED};
-	hsize_t chunk_size[] = {3,3,3};
-	hsize_t *loaded_dims = NULL;
-	hsize_t *loaded_maxdims = NULL;
+	hsize_t chunk_size[] = {2,2,2};
+	hsize_t loaded_dims[] = {0,0,0};
+	hsize_t loaded_maxdims[] = {0,0,0};
 	int new_rank;
 	herr_t error;
 
@@ -147,15 +147,15 @@ test_hdf_dataset_extend(hid_t* file_fixture, gconstpointer udata)
 
 	new_rank = H5Sget_simple_extent_dims(new_space, loaded_dims, loaded_maxdims);
 	g_assert_cmpint(new_rank, ==, 3);
-	// g_assert_cmpint(loaded_dims[0], ==, 30);
-	// g_assert_cmpint(loaded_dims[1], ==, 40);
-	// g_assert_cmpint(loaded_dims[2], ==, 50);
-	// g_assert_true(loaded_maxdims[0] == H5S_UNLIMITED && loaded_maxdims[1] == H5S_UNLIMITED && loaded_maxdims[2] == H5S_UNLIMITED);
-
-	free(loaded_maxdims);
-	free(loaded_dims);
+	g_assert_cmpint(loaded_dims[0], ==, 30);
+	g_assert_cmpint(loaded_dims[1], ==, 40);
+	g_assert_cmpint(loaded_dims[2], ==, 50);
+	g_assert_true(loaded_maxdims[0] == H5S_UNLIMITED && loaded_maxdims[1] == H5S_UNLIMITED && loaded_maxdims[2] == H5S_UNLIMITED);
 
 	error = H5Dclose(set);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Pclose(dcpl);
 	g_assert_cmpint(error, >=, 0);
 
 	error = H5Ldelete(file, "chunked", H5P_DEFAULT);

--- a/test/hdf5/hdf-dataset.c
+++ b/test/hdf5/hdf-dataset.c
@@ -38,12 +38,12 @@
 #include "hdf-helper.h"
 
 static void
-create_open_close_delete(hid_t file, H5S_class_t space_type, gchar const *name, hid_t data_type, hsize_t rank, hsize_t* dims, hsize_t* maxdims, hsize_t* chunk_size)
+create_open_close_delete(hid_t file, H5S_class_t space_type, gchar const* name, hid_t data_type, hsize_t rank, hsize_t* dims, hsize_t* maxdims, hsize_t* chunk_size)
 {
 	hid_t space, set, dcpl;
 	herr_t error;
 
-	if(rank == 0)
+	if (rank == 0)
 	{
 		space = H5Screate(space_type);
 	}
@@ -56,7 +56,7 @@ create_open_close_delete(hid_t file, H5S_class_t space_type, gchar const *name, 
 	dcpl = H5Pcopy(H5P_DATASET_CREATE_DEFAULT);
 	g_assert_cmpint(dcpl, !=, H5I_INVALID_HID);
 
-	if(chunk_size != NULL)
+	if (chunk_size != NULL)
 	{
 		error = H5Pset_chunk(dcpl, rank, chunk_size);
 		g_assert_cmpint(error, >=, 0);
@@ -85,26 +85,26 @@ static void
 test_hdf_dataset_create_delete_open_close(hid_t* file_fixture, gconstpointer udata)
 {
 	hid_t file = *file_fixture;
-	hsize_t dims[] = {1,2,3};
-	hsize_t unlimitted_dim[] = {H5S_UNLIMITED, H5S_UNLIMITED, H5S_UNLIMITED};
-	hsize_t chunk_size[] = {3,3,3};
-	hsize_t zero_dim[] = {1,0,0};
+	hsize_t dims[] = { 1, 2, 3 };
+	hsize_t unlimitted_dim[] = { H5S_UNLIMITED, H5S_UNLIMITED, H5S_UNLIMITED };
+	hsize_t chunk_size[] = { 3, 3, 3 };
+	hsize_t zero_dim[] = { 1, 0, 0 };
 
-	(void) udata;
+	(void)udata;
 
 	// null
 	create_open_close_delete(file, H5S_NULL, "null", H5T_NATIVE_INT, 0, NULL, NULL, NULL);
-	
+
 	// scalar
 	create_open_close_delete(file, H5S_SCALAR, "scalar", H5T_NATIVE_INT, 0, NULL, NULL, NULL);
-	
+
 	// simple
 	create_open_close_delete(file, H5S_SIMPLE, "simple", H5T_NATIVE_INT, 3, dims, dims, NULL);
-	
+
 	// simple zero_dim
 	create_open_close_delete(file, H5S_SIMPLE, "simple_zero", H5T_NATIVE_INT, 3, zero_dim, zero_dim, NULL);
-	
-	// chunked	
+
+	// chunked
 	create_open_close_delete(file, H5S_SIMPLE, "chunked", H5T_NATIVE_INT, 3, dims, unlimitted_dim, chunk_size);
 }
 
@@ -113,16 +113,16 @@ test_hdf_dataset_extend(hid_t* file_fixture, gconstpointer udata)
 {
 	hid_t file = *file_fixture;
 	hid_t space, set, dcpl, new_space;
-	hsize_t dims[] = {12,12,12};
-	hsize_t new_dims[] = {30,40,50};
-	hsize_t unlimitted_dim[] = {H5S_UNLIMITED, H5S_UNLIMITED, H5S_UNLIMITED};
-	hsize_t chunk_size[] = {2,2,2};
-	hsize_t loaded_dims[] = {0,0,0};
-	hsize_t loaded_maxdims[] = {0,0,0};
+	hsize_t dims[] = { 12, 12, 12 };
+	hsize_t new_dims[] = { 30, 40, 50 };
+	hsize_t unlimitted_dim[] = { H5S_UNLIMITED, H5S_UNLIMITED, H5S_UNLIMITED };
+	hsize_t chunk_size[] = { 2, 2, 2 };
+	hsize_t loaded_dims[] = { 0, 0, 0 };
+	hsize_t loaded_maxdims[] = { 0, 0, 0 };
 	int new_rank;
 	herr_t error;
 
-	(void) udata;
+	(void)udata;
 
 	space = H5Screate_simple(3, dims, unlimitted_dim);
 	g_assert_cmpint(space, !=, H5I_INVALID_HID);
@@ -167,13 +167,13 @@ test_hdf_dataset_invalid_extend(hid_t* file_fixture, gconstpointer udata)
 {
 	hid_t file = *file_fixture;
 	hid_t space, set, dcpl;
-	hsize_t dims[] = {1,2,3};
-	hsize_t new_dims[] = {30,40,50};
-	hsize_t max_dims[] = {3, 4, 5};
-	hsize_t chunk_size[] = {3,3,3};
+	hsize_t dims[] = { 1, 2, 3 };
+	hsize_t new_dims[] = { 30, 40, 50 };
+	hsize_t max_dims[] = { 3, 4, 5 };
+	hsize_t chunk_size[] = { 3, 3, 3 };
 	herr_t error;
 
-	(void) udata;
+	(void)udata;
 
 	space = H5Screate_simple(3, dims, max_dims);
 	g_assert_cmpint(space, !=, H5I_INVALID_HID);
@@ -206,11 +206,11 @@ test_hdf_dataset_write_read(hid_t* file_fixture, gconstpointer udata)
 	hid_t file = *file_fixture;
 	hid_t space, set;
 	hsize_t rank = 2;
-	hsize_t dim[] = {1000,1000};
-	g_autofree int *data = NULL;
+	hsize_t dim[] = { 1000, 1000 };
+	g_autofree int* data = NULL;
 	herr_t error;
 
-	(void) udata;
+	(void)udata;
 
 	// create dataspace and set
 	space = H5Screate_simple(rank, dim, dim);
@@ -221,7 +221,8 @@ test_hdf_dataset_write_read(hid_t* file_fixture, gconstpointer udata)
 
 	// generate data
 	data = g_malloc(1000000 * sizeof(int));
-	for(int i = 0; i < 999999; ++i) data[i] = i;
+	for (int i = 0; i < 999999; ++i)
+		data[i] = i;
 
 	// write data
 	error = H5Dwrite(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
@@ -232,7 +233,8 @@ test_hdf_dataset_write_read(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	// check data
-	for(int i = 0; i < 999999; ++i) g_assert_cmpint(data[i], ==, i);
+	for (int i = 0; i < 999999; ++i)
+		g_assert_cmpint(data[i], ==, i);
 
 	error = H5Dclose(set);
 	g_assert_cmpint(error, >=, 0);
@@ -247,16 +249,16 @@ test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
 	hid_t file = *file_fixture;
 	hid_t space, set, hyperslab, mem_space;
 	hsize_t rank = 2;
-	hsize_t dim[] = {1000, 1000};
-	hsize_t start[] = {0, 0};
-	hsize_t stride[] = {2, 2};
-	hsize_t count[] = {500, 500};
-	g_autofree int *data = NULL;
-	g_autofree int *write_data = NULL;
-	g_autofree int *read_data = NULL;
+	hsize_t dim[] = { 1000, 1000 };
+	hsize_t start[] = { 0, 0 };
+	hsize_t stride[] = { 2, 2 };
+	hsize_t count[] = { 500, 500 };
+	g_autofree int* data = NULL;
+	g_autofree int* write_data = NULL;
+	g_autofree int* read_data = NULL;
 	herr_t error;
 
-	(void) udata;
+	(void)udata;
 
 	// create dataspace and set
 	space = H5Screate_simple(rank, dim, dim);
@@ -267,7 +269,8 @@ test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
 
 	// generate data
 	data = g_malloc(1000000 * sizeof(int));
-	for(int i = 0; i < 999999; ++i) data[i] = 9001;
+	for (int i = 0; i < 999999; ++i)
+		data[i] = 9001;
 
 	// write data
 	error = H5Dwrite(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
@@ -281,7 +284,8 @@ test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	write_data = g_malloc(250000 * sizeof(int));
-	for(int i = 0; i < 249999; ++i) write_data[i] = 42;
+	for (int i = 0; i < 249999; ++i)
+		write_data[i] = 42;
 
 	// space of mem data
 	mem_space = H5Screate_simple(rank, count, count);
@@ -296,7 +300,8 @@ test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
 	error = H5Dread(set, H5T_NATIVE_INT, mem_space, hyperslab, H5P_DEFAULT, read_data);
 
 	// check data
-	for(int i = 0; i < 249999; ++i) g_assert_cmpint(read_data[i], ==, 42);
+	for (int i = 0; i < 249999; ++i)
+		g_assert_cmpint(read_data[i], ==, 42);
 
 	error = H5Dclose(set);
 	g_assert_cmpint(error, >=, 0);
@@ -317,12 +322,12 @@ test_hdf_dataset_write_read_chunked(hid_t* file_fixture, gconstpointer udata)
 	hid_t file = *file_fixture;
 	hid_t space, set, dcpl;
 	hsize_t rank = 2;
-	hsize_t dim[] = {1000,1000};
-	hsize_t chunk_size[] = {100,100};
-	g_autofree int *data = NULL;
+	hsize_t dim[] = { 1000, 1000 };
+	hsize_t chunk_size[] = { 100, 100 };
+	g_autofree int* data = NULL;
 	herr_t error;
 
-	(void) udata;
+	(void)udata;
 
 	// create dataspace and set
 	space = H5Screate_simple(rank, dim, dim);
@@ -339,7 +344,8 @@ test_hdf_dataset_write_read_chunked(hid_t* file_fixture, gconstpointer udata)
 
 	// generate data
 	data = g_malloc(1000000 * sizeof(int));
-	for(int i = 0; i < 999999; ++i) data[i] = i;
+	for (int i = 0; i < 999999; ++i)
+		data[i] = i;
 
 	// write data
 	error = H5Dwrite(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);
@@ -350,7 +356,8 @@ test_hdf_dataset_write_read_chunked(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	// check data
-	for(int i = 0; i < 999999; ++i) g_assert_cmpint(data[i], ==, i);
+	for (int i = 0; i < 999999; ++i)
+		g_assert_cmpint(data[i], ==, i);
 
 	error = H5Dclose(set);
 	g_assert_cmpint(error, >=, 0);
@@ -365,15 +372,15 @@ test_hdf_dataset_write_read_single(hid_t* file_fixture, gconstpointer udata)
 	hid_t file = *file_fixture;
 	hid_t space, set, elements, mem_space;
 	hsize_t rank = 2;
-	hsize_t dim[] = {1000, 1000};
+	hsize_t dim[] = { 1000, 1000 };
 	hsize_t n = 1;
-	hsize_t coord[2] = {3,3};
-	g_autofree int *data = NULL;
+	hsize_t coord[2] = { 3, 3 };
+	g_autofree int* data = NULL;
 	int write = 42;
 	int read = 0;
 	herr_t error;
 
-	(void) udata;
+	(void)udata;
 
 	// create dataspace and set
 	space = H5Screate_simple(rank, dim, dim);
@@ -384,7 +391,8 @@ test_hdf_dataset_write_read_single(hid_t* file_fixture, gconstpointer udata)
 
 	// generate data
 	data = g_malloc(1000000 * sizeof(int));
-	for(int i = 0; i < 999999; ++i) data[i] = 9001;
+	for (int i = 0; i < 999999; ++i)
+		data[i] = 9001;
 
 	// write data
 	error = H5Dwrite(set, H5T_NATIVE_INT, space, space, H5P_DEFAULT, data);

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -1,7 +1,6 @@
 /*
  * JULEA - Flexible storage framework
- * Copyright (C) 2018-2019 Johannes Coym
- * Copyright (C) 2019-2021 Michael Kuhn
+ * Copyright (C) 2021 Timm Leon Erxleben
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -60,7 +60,6 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
         } some_struct;
     } example_compound;
 
-
     // create datatypes
     compound_type = H5Tcreate(H5T_COMPOUND, sizeof(example_compound));
     g_assert_cmpint(compound_type, >=, 0);
@@ -83,7 +82,7 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
     g_assert_cmpint(error, >=, 0);
     error = H5Tinsert(compound_type, "some_array", HOFFSET(example_compound, some_array), array_type);
     g_assert_cmpint(error, >=, 0);
-    error = H5Tinsert(compound_type, "some_int", HOFFSET(example_compound, some_struct), another_compound_type);
+    error = H5Tinsert(compound_type, "some_struct", HOFFSET(example_compound, some_struct), another_compound_type);
     g_assert_cmpint(error, >=, 0);
 
     // commit type (e.g. save it to file)
@@ -101,13 +100,13 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
 
     // check members
     t0 = H5Tget_member_type(compound_type, 0);
-    g_assert_cmpint(H5T_equal(t0, H5T_NATIVE_INT), >, 0);
+    g_assert_cmpint(H5Tequal(t0, H5T_NATIVE_INT), >, 0);
     t1 = H5Tget_member_type(compound_type, 1);
-    g_assert_cmpint(H5T_equal(t1, H5T_NATIVE_FLOAT), >, 0);
+    g_assert_cmpint(H5Tequal(t1, H5T_NATIVE_FLOAT), >, 0);
     t2 = H5Tget_member_type(compound_type, 2);
-    g_assert_cmpint(H5T_equal(t2, array_type), >, 0);
+    g_assert_cmpint(H5Tequal(t2, array_type), >, 0);
     t3 = H5Tget_member_type(compound_type, 3);
-    g_assert_cmpint(H5T_equal(t0, another_compound_type), >, 0);
+    g_assert_cmpint(H5Tequal(t0, another_compound_type), >, 0);
     
     // clean up
     error = H5Tclose(compound_type);
@@ -116,6 +115,9 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
     g_assert_cmpint(error, >=, 0);
     error = H5Tclose(array_type);
     g_assert_cmpint(error, >=, 0);
+
+    g_test_incomplete("datatype commit is not yet implemented!");
+    /// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
 }
 
 #endif

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -120,6 +120,38 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
     /// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
 }
 
+static void
+test_hdf_datatype_create_array(hid_t* file_fixture, gconstpointer udata)
+{
+    hid_t array_type;
+    hid_t file = *file_fixture;
+    herr_t error;
+    hsize_t dim = 4;
+    (void) udata;
+
+    array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
+    g_assert_cmpint(array_type, >=, 0);
+
+    // commit type (e.g. save it to file)
+    error = H5Tcommit2(file, "/test_dtype", array_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    g_assert_cmpint(error, >=, 0);
+
+    // refresh type (reopens and loads from file)
+    error = H5Trefresh(array_type);
+    g_assert_cmpint(error, >=, 0);
+
+    // check type
+    g_assert_cmpint(H5Tget_class(array_type), ==, H5T_ARRAY);
+    g_assert_cmpint(H5Tget_size(array_type), ==, dim*sizeof(int));
+    
+    // clean up
+    error = H5Tclose(array_type);
+    g_assert_cmpint(error, >=, 0);
+
+    g_test_incomplete("datatype commit is not yet implemented!");
+    /// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
+}
+
 #endif
 
 void
@@ -131,6 +163,7 @@ test_hdf_datatype(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
+    g_test_add("/hdf/datatype-create_array", hid_t*, NULL,j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
     g_test_add("/hdf/datatype-create_compound", hid_t*, NULL, j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
 
 #endif

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -164,8 +164,8 @@ test_hdf_datatype(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
-    g_test_add("/hdf/datatype-create_array", hid_t, NULL,j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
-    g_test_add("/hdf/datatype-create_compound", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
+    g_test_add("/hdf5/datatype-create_array", hid_t, NULL,j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
+    g_test_add("/hdf5/datatype-create_compound", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
 
 #endif
 }

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -164,8 +164,8 @@ test_hdf_datatype(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
-    g_test_add("/hdf5/datatype-create_array", hid_t, NULL,j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
-    g_test_add("/hdf5/datatype-create_compound", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
+    g_test_add("/hdf5/datatype-create_array", hid_t, "array.h5",j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
+    g_test_add("/hdf5/datatype-create_compound", hid_t, "compound.h5", j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
 
 #endif
 }

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -45,7 +45,6 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
     hid_t file = *file_fixture;
     herr_t error;
     hsize_t dim = 4;
-    (void) udata;
 
     // example to be build as hdf5 type
     typedef struct example_compound
@@ -59,6 +58,8 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
             int yet_another_int;
         } some_struct;
     } example_compound;
+    
+    (void) udata;
 
     // create datatypes
     compound_type = H5Tcreate(H5T_COMPOUND, sizeof(example_compound));
@@ -106,7 +107,7 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
     t2 = H5Tget_member_type(compound_type, 2);
     g_assert_cmpint(H5Tequal(t2, array_type), >, 0);
     t3 = H5Tget_member_type(compound_type, 3);
-    g_assert_cmpint(H5Tequal(t0, another_compound_type), >, 0);
+    g_assert_cmpint(H5Tequal(t3, another_compound_type), >, 0);
     
     // clean up
     error = H5Tclose(compound_type);
@@ -163,8 +164,8 @@ test_hdf_datatype(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
-    g_test_add("/hdf/datatype-create_array", hid_t*, NULL,j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
-    g_test_add("/hdf/datatype-create_compound", hid_t*, NULL, j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
+    g_test_add("/hdf/datatype-create_array", hid_t, NULL,j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
+    g_test_add("/hdf/datatype-create_compound", hid_t, NULL, j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
 
 #endif
 }

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -61,6 +61,8 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
 
 	(void)udata;
 
+	J_TEST_TRAP_START;
+
 	// create datatypes
 	compound_type = H5Tcreate(H5T_COMPOUND, sizeof(example_compound));
 	g_assert_cmpint(compound_type, >=, 0);
@@ -117,8 +119,9 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
 	error = H5Tclose(array_type);
 	g_assert_cmpint(error, >=, 0);
 
+	J_TEST_TRAP_END;
+
 	g_test_incomplete("datatype commit is not yet implemented!");
-	/// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
 }
 
 static void
@@ -129,6 +132,8 @@ test_hdf_datatype_create_array(hid_t* file_fixture, gconstpointer udata)
 	herr_t error;
 	hsize_t dim = 4;
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
 	g_assert_cmpint(array_type, >=, 0);
@@ -149,8 +154,9 @@ test_hdf_datatype_create_array(hid_t* file_fixture, gconstpointer udata)
 	error = H5Tclose(array_type);
 	g_assert_cmpint(error, >=, 0);
 
+	J_TEST_TRAP_END;
+
 	g_test_incomplete("datatype commit is not yet implemented!");
-	/// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
 }
 
 #endif
@@ -164,8 +170,8 @@ test_hdf_datatype(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
-	g_test_add("/hdf5/datatype-create_array", hid_t, "array.h5", j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/datatype-create_compound", hid_t, "compound.h5", j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/datatype/create_array", hid_t, "array.h5", j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/datatype/create_compound", hid_t, "compound.h5", j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
 
 #endif
 }

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -40,117 +40,117 @@
 static void
 test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
 {
-    hid_t compound_type, array_type, another_compound_type;
-    hid_t t0, t1, t2, t3; // retrieved types from compound_type
-    hid_t file = *file_fixture;
-    herr_t error;
-    hsize_t dim = 4;
+	hid_t compound_type, array_type, another_compound_type;
+	hid_t t0, t1, t2, t3; // retrieved types from compound_type
+	hid_t file = *file_fixture;
+	herr_t error;
+	hsize_t dim = 4;
 
-    // example to be build as hdf5 type
-    typedef struct example_compound
-    {
-        int some_int;
-        float some_float;
-        float some_array[4];
-        struct
-        {
-            int another_int;
-            int yet_another_int;
-        } some_struct;
-    } example_compound;
-    
-    (void) udata;
+	// example to be build as hdf5 type
+	typedef struct example_compound
+	{
+		int some_int;
+		float some_float;
+		float some_array[4];
+		struct
+		{
+			int another_int;
+			int yet_another_int;
+		} some_struct;
+	} example_compound;
 
-    // create datatypes
-    compound_type = H5Tcreate(H5T_COMPOUND, sizeof(example_compound));
-    g_assert_cmpint(compound_type, >=, 0);
+	(void)udata;
 
-    array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
-    g_assert_cmpint(array_type, >=, 0);
+	// create datatypes
+	compound_type = H5Tcreate(H5T_COMPOUND, sizeof(example_compound));
+	g_assert_cmpint(compound_type, >=, 0);
 
-    another_compound_type = H5Tcreate(H5T_COMPOUND, 2*sizeof(int));
-    g_assert_cmpint(another_compound_type, >=, 0);
+	array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
+	g_assert_cmpint(array_type, >=, 0);
 
-    // fill compounds
-    error = H5Tinsert(another_compound_type, "another_int", 0, H5T_NATIVE_INT);
-    g_assert_cmpint(error, >=, 0);
-    error = H5Tinsert(another_compound_type, "yet_another_int", sizeof(int), H5T_NATIVE_INT);
-    g_assert_cmpint(error, >=, 0);
+	another_compound_type = H5Tcreate(H5T_COMPOUND, 2 * sizeof(int));
+	g_assert_cmpint(another_compound_type, >=, 0);
 
-    error = H5Tinsert(compound_type, "some_int", HOFFSET(example_compound, some_int), H5T_NATIVE_INT);
-    g_assert_cmpint(error, >=, 0);
-    error = H5Tinsert(compound_type, "some_float", HOFFSET(example_compound, some_float), H5T_NATIVE_FLOAT);
-    g_assert_cmpint(error, >=, 0);
-    error = H5Tinsert(compound_type, "some_array", HOFFSET(example_compound, some_array), array_type);
-    g_assert_cmpint(error, >=, 0);
-    error = H5Tinsert(compound_type, "some_struct", HOFFSET(example_compound, some_struct), another_compound_type);
-    g_assert_cmpint(error, >=, 0);
+	// fill compounds
+	error = H5Tinsert(another_compound_type, "another_int", 0, H5T_NATIVE_INT);
+	g_assert_cmpint(error, >=, 0);
+	error = H5Tinsert(another_compound_type, "yet_another_int", sizeof(int), H5T_NATIVE_INT);
+	g_assert_cmpint(error, >=, 0);
 
-    // commit type (e.g. save it to file)
-    error = H5Tcommit2(file, "/test_dtype", compound_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    g_assert_cmpint(error, >=, 0);
+	error = H5Tinsert(compound_type, "some_int", HOFFSET(example_compound, some_int), H5T_NATIVE_INT);
+	g_assert_cmpint(error, >=, 0);
+	error = H5Tinsert(compound_type, "some_float", HOFFSET(example_compound, some_float), H5T_NATIVE_FLOAT);
+	g_assert_cmpint(error, >=, 0);
+	error = H5Tinsert(compound_type, "some_array", HOFFSET(example_compound, some_array), array_type);
+	g_assert_cmpint(error, >=, 0);
+	error = H5Tinsert(compound_type, "some_struct", HOFFSET(example_compound, some_struct), another_compound_type);
+	g_assert_cmpint(error, >=, 0);
 
-    // refresh type (reopens and loads from file)
-    error = H5Trefresh(compound_type);
-    g_assert_cmpint(error, >=, 0);
+	// commit type (e.g. save it to file)
+	error = H5Tcommit2(file, "/test_dtype", compound_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
 
-    // check type
-    g_assert_cmpint(H5Tget_class(compound_type), ==, H5T_COMPOUND);
-    g_assert_cmpint(H5Tget_size(compound_type), ==, sizeof(example_compound));
-    g_assert_cmpint(H5Tget_nmembers(compound_type), ==, 4);
+	// refresh type (reopens and loads from file)
+	error = H5Trefresh(compound_type);
+	g_assert_cmpint(error, >=, 0);
 
-    // check members
-    t0 = H5Tget_member_type(compound_type, 0);
-    g_assert_cmpint(H5Tequal(t0, H5T_NATIVE_INT), >, 0);
-    t1 = H5Tget_member_type(compound_type, 1);
-    g_assert_cmpint(H5Tequal(t1, H5T_NATIVE_FLOAT), >, 0);
-    t2 = H5Tget_member_type(compound_type, 2);
-    g_assert_cmpint(H5Tequal(t2, array_type), >, 0);
-    t3 = H5Tget_member_type(compound_type, 3);
-    g_assert_cmpint(H5Tequal(t3, another_compound_type), >, 0);
-    
-    // clean up
-    error = H5Tclose(compound_type);
-    g_assert_cmpint(error, >=, 0);
-    error = H5Tclose(another_compound_type);
-    g_assert_cmpint(error, >=, 0);
-    error = H5Tclose(array_type);
-    g_assert_cmpint(error, >=, 0);
+	// check type
+	g_assert_cmpint(H5Tget_class(compound_type), ==, H5T_COMPOUND);
+	g_assert_cmpint(H5Tget_size(compound_type), ==, sizeof(example_compound));
+	g_assert_cmpint(H5Tget_nmembers(compound_type), ==, 4);
 
-    g_test_incomplete("datatype commit is not yet implemented!");
-    /// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
+	// check members
+	t0 = H5Tget_member_type(compound_type, 0);
+	g_assert_cmpint(H5Tequal(t0, H5T_NATIVE_INT), >, 0);
+	t1 = H5Tget_member_type(compound_type, 1);
+	g_assert_cmpint(H5Tequal(t1, H5T_NATIVE_FLOAT), >, 0);
+	t2 = H5Tget_member_type(compound_type, 2);
+	g_assert_cmpint(H5Tequal(t2, array_type), >, 0);
+	t3 = H5Tget_member_type(compound_type, 3);
+	g_assert_cmpint(H5Tequal(t3, another_compound_type), >, 0);
+
+	// clean up
+	error = H5Tclose(compound_type);
+	g_assert_cmpint(error, >=, 0);
+	error = H5Tclose(another_compound_type);
+	g_assert_cmpint(error, >=, 0);
+	error = H5Tclose(array_type);
+	g_assert_cmpint(error, >=, 0);
+
+	g_test_incomplete("datatype commit is not yet implemented!");
+	/// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
 }
 
 static void
 test_hdf_datatype_create_array(hid_t* file_fixture, gconstpointer udata)
 {
-    hid_t array_type;
-    hid_t file = *file_fixture;
-    herr_t error;
-    hsize_t dim = 4;
-    (void) udata;
+	hid_t array_type;
+	hid_t file = *file_fixture;
+	herr_t error;
+	hsize_t dim = 4;
+	(void)udata;
 
-    array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
-    g_assert_cmpint(array_type, >=, 0);
+	array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
+	g_assert_cmpint(array_type, >=, 0);
 
-    // commit type (e.g. save it to file)
-    error = H5Tcommit2(file, "/test_dtype", array_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    g_assert_cmpint(error, >=, 0);
+	// commit type (e.g. save it to file)
+	error = H5Tcommit2(file, "/test_dtype", array_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
 
-    // refresh type (reopens and loads from file)
-    error = H5Trefresh(array_type);
-    g_assert_cmpint(error, >=, 0);
+	// refresh type (reopens and loads from file)
+	error = H5Trefresh(array_type);
+	g_assert_cmpint(error, >=, 0);
 
-    // check type
-    g_assert_cmpint(H5Tget_class(array_type), ==, H5T_ARRAY);
-    g_assert_cmpint(H5Tget_size(array_type), ==, dim*sizeof(int));
-    
-    // clean up
-    error = H5Tclose(array_type);
-    g_assert_cmpint(error, >=, 0);
+	// check type
+	g_assert_cmpint(H5Tget_class(array_type), ==, H5T_ARRAY);
+	g_assert_cmpint(H5Tget_size(array_type), ==, dim * sizeof(int));
 
-    g_test_incomplete("datatype commit is not yet implemented!");
-    /// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
+	// clean up
+	error = H5Tclose(array_type);
+	g_assert_cmpint(error, >=, 0);
+
+	g_test_incomplete("datatype commit is not yet implemented!");
+	/// \todo This causes a critical error and test abortion. Isolation test cases in different processes resolves this.
 }
 
 #endif
@@ -164,9 +164,8 @@ test_hdf_datatype(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
-    g_test_add("/hdf5/datatype-create_array", hid_t, "array.h5",j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
-    g_test_add("/hdf5/datatype-create_compound", hid_t, "compound.h5", j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/datatype-create_array", hid_t, "array.h5", j_test_hdf_file_fixture_setup, test_hdf_datatype_create_array, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/datatype-create_compound", hid_t, "compound.h5", j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
 
 #endif
 }
-

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -1,0 +1,136 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2018-2019 Johannes Coym
+ * Copyright (C) 2019-2021 Michael Kuhn
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#include <julea-config.h>
+
+#include <glib.h>
+
+#include <julea.h>
+
+#include "test.h"
+
+#ifdef HAVE_HDF5
+
+#include <julea-hdf5.h>
+
+#include <hdf5.h>
+
+#include "hdf-helper.h"
+
+static void
+test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
+{
+    hid_t compound_type, array_type, another_compound_type;
+    hid_t t0, t1, t2, t3; // retrieved types from compound_type
+    hid_t file = *file_fixture;
+    herr_t error;
+    hsize_t dim = 4;
+    (void) udata;
+
+    // example to be build as hdf5 type
+    typedef struct example_compound
+    {
+        int some_int;
+        float some_float;
+        float some_array[4];
+        struct
+        {
+            int another_int;
+            int yet_another_int;
+        } some_struct;
+    } example_compound;
+
+
+    // create datatypes
+    compound_type = H5Tcreate(H5T_COMPOUND, sizeof(example_compound));
+    g_assert_cmpint(compound_type, >=, 0);
+
+    array_type = H5Tarray_create2(H5T_NATIVE_FLOAT, 1, &dim);
+    g_assert_cmpint(array_type, >=, 0);
+
+    another_compound_type = H5Tcreate(H5T_COMPOUND, 2*sizeof(int));
+    g_assert_cmpint(another_compound_type, >=, 0);
+
+    // fill compounds
+    error = H5Tinsert(another_compound_type, "another_int", 0, H5T_NATIVE_INT);
+    g_assert_cmpint(error, >=, 0);
+    error = H5Tinsert(another_compound_type, "yet_another_int", sizeof(int), H5T_NATIVE_INT);
+    g_assert_cmpint(error, >=, 0);
+
+    error = H5Tinsert(compound_type, "some_int", HOFFSET(example_compound, some_int), H5T_NATIVE_INT);
+    g_assert_cmpint(error, >=, 0);
+    error = H5Tinsert(compound_type, "some_float", HOFFSET(example_compound, some_float), H5T_NATIVE_FLOAT);
+    g_assert_cmpint(error, >=, 0);
+    error = H5Tinsert(compound_type, "some_array", HOFFSET(example_compound, some_array), array_type);
+    g_assert_cmpint(error, >=, 0);
+    error = H5Tinsert(compound_type, "some_int", HOFFSET(example_compound, some_struct), another_compound_type);
+    g_assert_cmpint(error, >=, 0);
+
+    // commit type (e.g. save it to file)
+    error = H5Tcommit2(file, "/test_dtype", compound_type, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    g_assert_cmpint(error, >=, 0);
+
+    // refresh type (reopens and loads from file)
+    error = H5Trefresh(compound_type);
+    g_assert_cmpint(error, >=, 0);
+
+    // check type
+    g_assert_cmpint(H5Tget_class(compound_type), ==, H5T_COMPOUND);
+    g_assert_cmpint(H5Tget_size(compound_type), ==, sizeof(example_compound));
+    g_assert_cmpint(H5Tget_nmembers(compound_type), ==, 4);
+
+    // check members
+    t0 = H5Tget_member_type(compound_type, 0);
+    g_assert_cmpint(H5T_equal(t0, H5T_NATIVE_INT), >, 0);
+    t1 = H5Tget_member_type(compound_type, 1);
+    g_assert_cmpint(H5T_equal(t1, H5T_NATIVE_FLOAT), >, 0);
+    t2 = H5Tget_member_type(compound_type, 2);
+    g_assert_cmpint(H5T_equal(t2, array_type), >, 0);
+    t3 = H5Tget_member_type(compound_type, 3);
+    g_assert_cmpint(H5T_equal(t0, another_compound_type), >, 0);
+    
+    // clean up
+    error = H5Tclose(compound_type);
+    g_assert_cmpint(error, >=, 0);
+    error = H5Tclose(another_compound_type);
+    g_assert_cmpint(error, >=, 0);
+    error = H5Tclose(array_type);
+    g_assert_cmpint(error, >=, 0);
+}
+
+#endif
+
+void
+test_hdf_datatype(void)
+{
+#ifdef HAVE_HDF5
+	if (g_getenv("HDF5_VOL_CONNECTOR") == NULL)
+	{
+		// Running tests only makes sense for our HDF5 clients
+		return;
+	}
+    g_test_add("/hdf/datatype-create_compound", hid_t*, NULL, j_test_hdf_file_fixture_setup, test_hdf_datatype_create_compound, j_test_hdf_file_fixture_teardown);
+
+#endif
+}
+

--- a/test/hdf5/hdf-file.c
+++ b/test/hdf5/hdf-file.c
@@ -126,6 +126,11 @@ test_hdf_file_open_non_existent(void)
 	g_assert_cmpint(file, ==, H5I_INVALID_HID);
 
 	J_TEST_TRAP_END;
+
+	if (g_str_equal(g_getenv("HDF5_VOL_CONNECTOR"), "julea-kv"))
+	{
+		g_test_incomplete("Fails currently for julea-kv");
+	}
 }
 
 static void

--- a/test/hdf5/hdf-file.c
+++ b/test/hdf5/hdf-file.c
@@ -1,7 +1,6 @@
 /*
  * JULEA - Flexible storage framework
- * Copyright (C) 2018-2019 Johannes Coym
- * Copyright (C) 2019-2021 Michael Kuhn
+ * Copyright (C) 2021 Timm Leon Erxleben
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/test/hdf5/hdf-file.c
+++ b/test/hdf5/hdf-file.c
@@ -1,0 +1,165 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2018-2019 Johannes Coym
+ * Copyright (C) 2019-2021 Michael Kuhn
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#include <julea-config.h>
+
+#include <glib.h>
+
+#include <julea.h>
+
+#include "test.h"
+
+#ifdef HAVE_HDF5
+
+#include <julea-hdf5.h>
+
+#include <hdf5.h>
+
+#include "hdf-helper.h"
+
+static void
+test_hdf_file_create_delete(void)
+{
+	hid_t file;
+	herr_t error;
+	
+	file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(file, !=, H5I_INVALID_HID);
+
+	/// \todo maybe implement reopen (part of file specific)
+	error = H5Fclose(file);
+	g_assert_cmpint(error, >=, 0);
+
+	file = H5Fopen("test_file.h5", H5F_ACC_RDWR, H5P_DEFAULT);
+	g_assert_cmpint(file, !=, H5I_INVALID_HID);
+
+	error = H5Fclose(file);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Fdelete("test_file.h5", H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_file_double_create(void)
+{
+	hid_t file;
+	herr_t error;
+	
+	file = H5Fcreate("test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(file, !=, H5I_INVALID_HID);
+
+	file = H5Fcreate("test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(file, ==, H5I_INVALID_HID);
+
+	error = H5Fdelete("test_file.h5", H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
+
+	g_test_incomplete("delete not implemented yet");
+}
+
+static void
+test_hdf_file_open_close(void)
+{
+	hid_t file;
+	herr_t error;
+
+	file = H5Fcreate("test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(file, !=, H5I_INVALID_HID);
+
+	error = H5Fclose(file);
+	g_assert_cmpint(error, >=, 0);
+
+	file = H5Fopen("test_file.h5", H5F_ACC_RDWR, H5P_DEFAULT);
+	g_assert_cmpint(file, !=, H5I_INVALID_HID);
+
+	error = H5Fclose(file);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Fdelete("test_file.h5", H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
+
+	g_test_incomplete("delete not implemented yet");
+}
+
+static void
+test_hdf_file_open_non_existent(void)
+{
+	hid_t file;
+
+	file = H5Fopen("non-existent.h5", H5F_ACC_RDWR, H5P_DEFAULT);
+	g_assert_cmpint(file, ==, H5I_INVALID_HID);
+}
+
+static void
+test_hdf_file_delete(void)
+{
+	hid_t file;
+	herr_t error;
+	
+	file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(file, !=, H5I_INVALID_HID);
+
+	error = H5Fclose(file);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Fdelete("test_file.h5", H5P_DEFAULT);
+	g_assert_cmpint(error, >=, 0);
+
+	file = H5Fopen("test_file.h5", H5F_ACC_RDWR, H5P_DEFAULT);
+	g_assert_cmpint(file, ==, H5I_INVALID_HID);
+
+	g_test_incomplete("delete not implemented yet");
+}
+
+static void
+test_hdf_file_delete_non_existent(void)
+{
+	herr_t error;
+
+	error = H5Fdelete("non-existent.h5", H5P_DEFAULT);
+	g_assert_cmpint(error, <, 0);
+
+	g_test_incomplete("delete not implemented yet");
+}
+
+#endif
+
+void
+test_hdf_file(void)
+{
+#ifdef HAVE_HDF5
+	if (g_getenv("HDF5_VOL_CONNECTOR") == NULL)
+	{
+		// Running tests only makes sense for our HDF5 clients
+		return;
+	}
+	g_test_add_func("/hdf5/file-create_delete", test_hdf_file_create_delete);
+	g_test_add_func("/hdf5/file-double_create", test_hdf_file_double_create);
+	g_test_add_func("/hdf5/file-open_close", test_hdf_file_open_close);
+	g_test_add_func("/hdf5/file-open_non_existent", test_hdf_file_open_non_existent);
+	g_test_add_func("/hdf5/file-delete", test_hdf_file_delete);
+	g_test_add_func("/hdf5/file-double_delete", test_hdf_file_delete_non_existent);
+
+#endif
+}

--- a/test/hdf5/hdf-file.c
+++ b/test/hdf5/hdf-file.c
@@ -66,13 +66,13 @@ test_hdf_file_double_create(void)
 	hid_t file;
 	herr_t error;
 	
-	file = H5Fcreate("test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
+	file = H5Fcreate("excl_test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
 
-	file = H5Fcreate("test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
+	file = H5Fcreate("excl_test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, ==, H5I_INVALID_HID);
 
-	error = H5Fdelete("test_file.h5", H5P_DEFAULT);
+	error = H5Fdelete("excl_test_file.h5", H5P_DEFAULT);
 	g_assert_cmpint(error, >=, 0);
 
 	g_test_incomplete("delete not implemented yet");
@@ -84,7 +84,7 @@ test_hdf_file_open_close(void)
 	hid_t file;
 	herr_t error;
 
-	file = H5Fcreate("test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
+	file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
 
 	error = H5Fclose(file);

--- a/test/hdf5/hdf-file.c
+++ b/test/hdf5/hdf-file.c
@@ -43,6 +43,8 @@ test_hdf_file_create_delete(void)
 	hid_t file;
 	herr_t error;
 
+	J_TEST_TRAP_START;
+
 	file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
 
@@ -58,6 +60,10 @@ test_hdf_file_create_delete(void)
 
 	error = H5Fdelete("test_file.h5", H5P_DEFAULT);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
+
+	g_test_incomplete("delete not implemented yet");
 }
 
 static void
@@ -65,6 +71,8 @@ test_hdf_file_double_create(void)
 {
 	hid_t file;
 	herr_t error;
+
+	J_TEST_TRAP_START;
 
 	file = H5Fcreate("excl_test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
@@ -75,6 +83,8 @@ test_hdf_file_double_create(void)
 	error = H5Fdelete("excl_test_file.h5", H5P_DEFAULT);
 	g_assert_cmpint(error, >=, 0);
 
+	J_TEST_TRAP_END;
+
 	g_test_incomplete("delete not implemented yet");
 }
 
@@ -84,6 +94,8 @@ test_hdf_file_open_close(void)
 	hid_t file;
 	herr_t error;
 
+	J_TEST_TRAP_START;
+
 	file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
 
@@ -98,6 +110,8 @@ test_hdf_file_open_close(void)
 
 	error = H5Fdelete("test_file.h5", H5P_DEFAULT);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 
 	g_test_incomplete("delete not implemented yet");
 }
@@ -107,8 +121,12 @@ test_hdf_file_open_non_existent(void)
 {
 	hid_t file;
 
+	J_TEST_TRAP_START;
+
 	file = H5Fopen("non-existent.h5", H5F_ACC_RDWR, H5P_DEFAULT);
 	g_assert_cmpint(file, ==, H5I_INVALID_HID);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -116,6 +134,8 @@ test_hdf_file_delete(void)
 {
 	hid_t file;
 	herr_t error;
+
+	J_TEST_TRAP_START;
 
 	file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
@@ -129,6 +149,8 @@ test_hdf_file_delete(void)
 	file = H5Fopen("test_file.h5", H5F_ACC_RDWR, H5P_DEFAULT);
 	g_assert_cmpint(file, ==, H5I_INVALID_HID);
 
+	J_TEST_TRAP_END;
+
 	g_test_incomplete("delete not implemented yet");
 }
 
@@ -137,8 +159,12 @@ test_hdf_file_delete_non_existent(void)
 {
 	herr_t error;
 
+	J_TEST_TRAP_START;
+
 	error = H5Fdelete("non-existent.h5", H5P_DEFAULT);
 	g_assert_cmpint(error, <, 0);
+
+	J_TEST_TRAP_END;
 
 	g_test_incomplete("delete not implemented yet");
 }
@@ -154,12 +180,12 @@ test_hdf_file(void)
 		// Running tests only makes sense for our HDF5 clients
 		return;
 	}
-	g_test_add_func("/hdf5/file-create_delete", test_hdf_file_create_delete);
-	g_test_add_func("/hdf5/file-double_create", test_hdf_file_double_create);
-	g_test_add_func("/hdf5/file-open_close", test_hdf_file_open_close);
-	g_test_add_func("/hdf5/file-open_non_existent", test_hdf_file_open_non_existent);
-	g_test_add_func("/hdf5/file-delete", test_hdf_file_delete);
-	g_test_add_func("/hdf5/file-double_delete", test_hdf_file_delete_non_existent);
+	g_test_add_func("/hdf5/file/create_delete", test_hdf_file_create_delete);
+	g_test_add_func("/hdf5/file/double_create", test_hdf_file_double_create);
+	g_test_add_func("/hdf5/file/open_close", test_hdf_file_open_close);
+	g_test_add_func("/hdf5/file/open_non_existent", test_hdf_file_open_non_existent);
+	g_test_add_func("/hdf5/file/delete", test_hdf_file_delete);
+	g_test_add_func("/hdf5/file/double_delete", test_hdf_file_delete_non_existent);
 
 #endif
 }

--- a/test/hdf5/hdf-file.c
+++ b/test/hdf5/hdf-file.c
@@ -42,7 +42,7 @@ test_hdf_file_create_delete(void)
 {
 	hid_t file;
 	herr_t error;
-	
+
 	file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
 
@@ -65,7 +65,7 @@ test_hdf_file_double_create(void)
 {
 	hid_t file;
 	herr_t error;
-	
+
 	file = H5Fcreate("excl_test_file.h5", H5F_ACC_EXCL, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
 
@@ -116,7 +116,7 @@ test_hdf_file_delete(void)
 {
 	hid_t file;
 	herr_t error;
-	
+
 	file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(file, !=, H5I_INVALID_HID);
 

--- a/test/hdf5/hdf-group-link.c
+++ b/test/hdf5/hdf-group-link.c
@@ -1,7 +1,6 @@
 /*
  * JULEA - Flexible storage framework
- * Copyright (C) 2018-2019 Johannes Coym
- * Copyright (C) 2019-2021 Michael Kuhn
+ * Copyright (C) 2021 Timm Leon Erxleben
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/test/hdf5/hdf-group-link.c
+++ b/test/hdf5/hdf-group-link.c
@@ -44,7 +44,7 @@ test_hdf_group_create_delete_open_close(hid_t* file_fixture, gconstpointer udata
 	hid_t group, error;
 	htri_t ret;
 
-	(void) udata;
+	(void)udata;
 
 	group = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group, !=, H5I_INVALID_HID);
@@ -75,7 +75,7 @@ test_hdf_link_nested_group(hid_t* file_fixture, gconstpointer udata)
 	hid_t group, nested_group, error;
 	htri_t ret;
 
-	(void) udata;
+	(void)udata;
 
 	group = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group, !=, H5I_INVALID_HID);
@@ -102,7 +102,7 @@ test_hdf_link_hard_delete(hid_t* file_fixture, gconstpointer udata)
 	hid_t file = *file_fixture;
 	hid_t group1, group2, error;
 
-	(void) udata;
+	(void)udata;
 
 	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group1, !=, H5I_INVALID_HID);
@@ -135,7 +135,7 @@ test_hdf_link_soft(hid_t* file_fixture, gconstpointer udata)
 	hid_t file = *file_fixture;
 	hid_t group1, group2, error;
 
-	(void) udata;
+	(void)udata;
 
 	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group1, !=, H5I_INVALID_HID);
@@ -165,7 +165,7 @@ test_hdf_link_invalid(hid_t* file_fixture, gconstpointer udata)
 	hid_t file = *file_fixture;
 	hid_t error;
 
-	(void) udata;
+	(void)udata;
 
 	error = H5Glink(file, H5G_LINK_SOFT, "test_group", "test_group2");
 	g_assert_cmpint(error, >=, 0); // creating soft links to non existing objects is allowed
@@ -175,12 +175,12 @@ test_hdf_link_invalid(hid_t* file_fixture, gconstpointer udata)
 }
 
 static herr_t
-it_op(hid_t group, const char *name, const H5L_info2_t *info, void *op_data)
+it_op(hid_t group, const char* name, const H5L_info2_t* info, void* op_data)
 {
 	int* count = (int*)op_data;
-	(void) info;
-	(void) group;
-	(void) name;
+	(void)info;
+	(void)group;
+	(void)name;
 
 	++(*count);
 	return 0;
@@ -193,7 +193,7 @@ test_hdf_link_iterate(hid_t* file_fixture, gconstpointer udata)
 	hid_t group1, group2, error;
 	int count = 0;
 
-	(void) udata;
+	(void)udata;
 
 	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group1, !=, H5I_INVALID_HID);

--- a/test/hdf5/hdf-group-link.c
+++ b/test/hdf5/hdf-group-link.c
@@ -1,0 +1,238 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2018-2019 Johannes Coym
+ * Copyright (C) 2019-2021 Michael Kuhn
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#include <julea-config.h>
+
+#include <glib.h>
+
+#include <julea.h>
+
+#include "test.h"
+
+#ifdef HAVE_HDF5
+
+#include <julea-hdf5.h>
+
+#include <hdf5.h>
+
+#include "hdf-helper.h"
+
+static void
+test_hdf_group_create_delete_open_close(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t group, error;
+	htri_t ret;
+
+	(void) udata;
+
+	group = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(group, !=, H5I_INVALID_HID);
+
+	error = H5Gclose(group);
+	g_assert_cmpint(error, >=, 0);
+
+	ret = H5Lexists(file, "/test_group", H5P_DEFAULT);
+	g_assert_cmpint(ret, >, 0);
+
+	group = H5Gopen(file, "/test_group", H5P_DEFAULT);
+	g_assert_cmpint(group, !=, H5I_INVALID_HID);
+
+	error = H5Gclose(group);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Gunlink(file, "/test_group");
+	g_assert_cmpint(error, >=, 0);
+
+	ret = H5Lexists(file, "/test_group", H5P_DEFAULT);
+	g_assert_cmpint(ret, ==, 0);
+}
+
+static void
+test_hdf_link_nested_group(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t group, nested_group, error;
+	htri_t ret;
+
+	(void) udata;
+
+	group = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(group, !=, H5I_INVALID_HID);
+
+	nested_group = H5Gcreate(group, "test_nested", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(nested_group, !=, H5I_INVALID_HID);
+
+	ret = H5Lexists(file, "/test_group/test_nested", H5P_DEFAULT);
+	g_assert_cmpint(ret, >, 0);
+
+	ret = H5Lexists(group, "test_nested", H5P_DEFAULT);
+	g_assert_cmpint(ret, >, 0);
+
+	error = H5Gclose(group);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Gclose(nested_group);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_link_hard_delete(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t group1, group2, error;
+
+	(void) udata;
+
+	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(group1, !=, H5I_INVALID_HID);
+
+	error = H5Glink(file, H5G_LINK_HARD, "test_group", "test_group2");
+	g_assert_cmpint(error, >=, 0);
+
+	group2 = H5Gopen(file, "/test_group2", H5P_DEFAULT);
+	g_assert_cmpint(group2, !=, H5I_INVALID_HID);
+
+	error = H5Gclose(group1);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Gclose(group2);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Gunlink(file, "/test_group");
+	g_assert_cmpint(error, >=, 0);
+
+	group2 = H5Gopen(file, "/test_group2", H5P_DEFAULT);
+	g_assert_cmpint(group2, !=, H5I_INVALID_HID);
+
+	error = H5Gclose(group2);
+	g_assert_cmpint(error, >=, 0);
+}
+
+static void
+test_hdf_link_soft(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t group1, group2, error;
+
+	(void) udata;
+
+	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(group1, !=, H5I_INVALID_HID);
+
+	error = H5Glink(file, H5G_LINK_SOFT, "test_group", "test_group2");
+	g_assert_cmpint(error, >=, 0);
+
+	group2 = H5Gopen(file, "/test_group2", H5P_DEFAULT);
+	g_assert_cmpint(group2, !=, H5I_INVALID_HID);
+
+	error = H5Gclose(group1);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Gclose(group2);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Gunlink(file, "/test_group");
+	g_assert_cmpint(error, >=, 0);
+
+	group2 = H5Gopen(file, "/test_group2", H5P_DEFAULT);
+	g_assert_cmpint(group2, ==, H5I_INVALID_HID);
+}
+
+static void
+test_hdf_link_invalid(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t error;
+
+	(void) udata;
+
+	error = H5Glink(file, H5G_LINK_SOFT, "test_group", "test_group2");
+	g_assert_cmpint(error, >=, 0); // creating soft links to non existing objects is allowed
+
+	error = H5Glink(file, H5G_LINK_HARD, "test_group", "test_group2");
+	g_assert_cmpint(error, <, 0);
+}
+
+static herr_t
+it_op(hid_t group, const char *name, const H5L_info2_t *info, void *op_data)
+{
+	int* count = (int*)op_data;
+	(void) info;
+	(void) group;
+	(void) name;
+
+	++(*count);
+	return 0;
+}
+
+static void
+test_hdf_link_iterate(hid_t* file_fixture, gconstpointer udata)
+{
+	hid_t file = *file_fixture;
+	hid_t group1, group2, error;
+	int count = 0;
+
+	(void) udata;
+
+	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(group1, !=, H5I_INVALID_HID);
+
+	error = H5Glink(file, H5G_LINK_SOFT, "test_group", "test_group2");
+	g_assert_cmpint(error, >=, 0);
+
+	group2 = H5Gcreate(group1, "test_nested", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	g_assert_cmpint(group2, !=, H5I_INVALID_HID);
+
+	error = H5Gclose(group1);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Gclose(group2);
+	g_assert_cmpint(error, >=, 0);
+
+	error = H5Literate(file, H5_INDEX_NAME, H5_ITER_NATIVE, NULL, it_op, &count);
+	g_assert_cmpint(error, >=, 0);
+	g_assert_cmpint(count, ==, 2);
+}
+
+#endif
+
+void
+test_hdf_group_link(void)
+{
+#ifdef HAVE_HDF5
+	if (g_getenv("HDF5_VOL_CONNECTOR") == NULL)
+	{
+		// Running tests only makes sense for our HDF5 clients
+		return;
+	}
+
+	g_test_add("/hdf5/group-create_delete_open_close", hid_t, "group_open_close.h5", j_test_hdf_file_fixture_setup, test_hdf_group_create_delete_open_close, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link-nested_group", hid_t, "l_nested.h5", j_test_hdf_file_fixture_setup, test_hdf_link_nested_group, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link-hard_delete", hid_t, "hardlink_delete.h5", j_test_hdf_file_fixture_setup, test_hdf_link_hard_delete, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link-soft", hid_t, "softlink_delete.h5", j_test_hdf_file_fixture_setup, test_hdf_link_soft, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link-invalid", hid_t, "invalid_link.h5", j_test_hdf_file_fixture_setup, test_hdf_link_invalid, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link-iterate", hid_t, "link_iterate.h5", j_test_hdf_file_fixture_setup, test_hdf_link_iterate, j_test_hdf_file_fixture_teardown);
+
+#endif
+}

--- a/test/hdf5/hdf-group-link.c
+++ b/test/hdf5/hdf-group-link.c
@@ -46,6 +46,8 @@ test_hdf_group_create_delete_open_close(hid_t* file_fixture, gconstpointer udata
 
 	(void)udata;
 
+	J_TEST_TRAP_START;
+
 	group = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group, !=, H5I_INVALID_HID);
 
@@ -66,6 +68,8 @@ test_hdf_group_create_delete_open_close(hid_t* file_fixture, gconstpointer udata
 
 	ret = H5Lexists(file, "/test_group", H5P_DEFAULT);
 	g_assert_cmpint(ret, ==, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -76,6 +80,8 @@ test_hdf_link_nested_group(hid_t* file_fixture, gconstpointer udata)
 	htri_t ret;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	group = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group, !=, H5I_INVALID_HID);
@@ -94,6 +100,8 @@ test_hdf_link_nested_group(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Gclose(nested_group);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -103,6 +111,8 @@ test_hdf_link_hard_delete(hid_t* file_fixture, gconstpointer udata)
 	hid_t group1, group2, error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group1, !=, H5I_INVALID_HID);
@@ -127,6 +137,8 @@ test_hdf_link_hard_delete(hid_t* file_fixture, gconstpointer udata)
 
 	error = H5Gclose(group2);
 	g_assert_cmpint(error, >=, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -136,6 +148,8 @@ test_hdf_link_soft(hid_t* file_fixture, gconstpointer udata)
 	hid_t group1, group2, error;
 
 	(void)udata;
+
+	J_TEST_TRAP_START;
 
 	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group1, !=, H5I_INVALID_HID);
@@ -157,6 +171,8 @@ test_hdf_link_soft(hid_t* file_fixture, gconstpointer udata)
 
 	group2 = H5Gopen(file, "/test_group2", H5P_DEFAULT);
 	g_assert_cmpint(group2, ==, H5I_INVALID_HID);
+
+	J_TEST_TRAP_END;
 }
 
 static void
@@ -167,11 +183,15 @@ test_hdf_link_invalid(hid_t* file_fixture, gconstpointer udata)
 
 	(void)udata;
 
+	J_TEST_TRAP_START;
+
 	error = H5Glink(file, H5G_LINK_SOFT, "test_group", "test_group2");
 	g_assert_cmpint(error, >=, 0); // creating soft links to non existing objects is allowed
 
 	error = H5Glink(file, H5G_LINK_HARD, "test_group", "test_group2");
 	g_assert_cmpint(error, <, 0);
+
+	J_TEST_TRAP_END;
 }
 
 static herr_t
@@ -195,6 +215,8 @@ test_hdf_link_iterate(hid_t* file_fixture, gconstpointer udata)
 
 	(void)udata;
 
+	J_TEST_TRAP_START;
+
 	group1 = H5Gcreate(file, "test_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 	g_assert_cmpint(group1, !=, H5I_INVALID_HID);
 
@@ -213,6 +235,8 @@ test_hdf_link_iterate(hid_t* file_fixture, gconstpointer udata)
 	error = H5Literate(file, H5_INDEX_NAME, H5_ITER_NATIVE, NULL, it_op, &count);
 	g_assert_cmpint(error, >=, 0);
 	g_assert_cmpint(count, ==, 2);
+
+	J_TEST_TRAP_END;
 }
 
 #endif
@@ -227,12 +251,12 @@ test_hdf_group_link(void)
 		return;
 	}
 
-	g_test_add("/hdf5/group-create_delete_open_close", hid_t, "group_open_close.h5", j_test_hdf_file_fixture_setup, test_hdf_group_create_delete_open_close, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/link-nested_group", hid_t, "l_nested.h5", j_test_hdf_file_fixture_setup, test_hdf_link_nested_group, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/link-hard_delete", hid_t, "hardlink_delete.h5", j_test_hdf_file_fixture_setup, test_hdf_link_hard_delete, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/link-soft", hid_t, "softlink_delete.h5", j_test_hdf_file_fixture_setup, test_hdf_link_soft, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/link-invalid", hid_t, "invalid_link.h5", j_test_hdf_file_fixture_setup, test_hdf_link_invalid, j_test_hdf_file_fixture_teardown);
-	g_test_add("/hdf5/link-iterate", hid_t, "link_iterate.h5", j_test_hdf_file_fixture_setup, test_hdf_link_iterate, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/group/create_delete_open_close", hid_t, "group_open_close.h5", j_test_hdf_file_fixture_setup, test_hdf_group_create_delete_open_close, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link/nested_group", hid_t, "l_nested.h5", j_test_hdf_file_fixture_setup, test_hdf_link_nested_group, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link/hard_delete", hid_t, "hardlink_delete.h5", j_test_hdf_file_fixture_setup, test_hdf_link_hard_delete, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link/soft", hid_t, "softlink_delete.h5", j_test_hdf_file_fixture_setup, test_hdf_link_soft, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link/invalid", hid_t, "invalid_link.h5", j_test_hdf_file_fixture_setup, test_hdf_link_invalid, j_test_hdf_file_fixture_teardown);
+	g_test_add("/hdf5/link/iterate", hid_t, "link_iterate.h5", j_test_hdf_file_fixture_setup, test_hdf_link_iterate, j_test_hdf_file_fixture_teardown);
 
 #endif
 }

--- a/test/hdf5/hdf-group-link.c
+++ b/test/hdf5/hdf-group-link.c
@@ -69,6 +69,8 @@ test_hdf_group_create_delete_open_close(hid_t* file_fixture, gconstpointer udata
 	g_assert_cmpint(ret, ==, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -101,6 +103,8 @@ test_hdf_link_nested_group(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -138,6 +142,8 @@ test_hdf_link_hard_delete(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, >=, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -172,6 +178,8 @@ test_hdf_link_soft(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(group2, ==, H5I_INVALID_HID);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static void
@@ -191,6 +199,8 @@ test_hdf_link_invalid(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(error, <, 0);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 static herr_t
@@ -236,6 +246,8 @@ test_hdf_link_iterate(hid_t* file_fixture, gconstpointer udata)
 	g_assert_cmpint(count, ==, 2);
 
 	J_TEST_TRAP_END;
+
+	g_test_incomplete("Fails currently");
 }
 
 #endif

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -1,7 +1,6 @@
 /*
  * JULEA - Flexible storage framework
- * Copyright (C) 2018-2019 Johannes Coym
- * Copyright (C) 2019-2021 Michael Kuhn
+ * Copyright (C) 2021 Timm Leon Erxleben
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -27,20 +27,16 @@
 
 void j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata)
 {
-    (void) udata;
+    const gchar* name = udata;
 
-    //*file = g_malloc(sizeof(hid_t));
-
-    *file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    *file = H5Fcreate(name, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 }
 
 void j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata)
 {
-    (void) udata;
+    const gchar* name = udata;
     H5Fclose(*file);
-    H5Fdelete("test_file.h5", H5P_DEFAULT);
-
-    //g_free(*file);
+    //H5Fdelete(name, H5P_DEFAULT);
 }
 
 #endif

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -25,18 +25,20 @@
 
 #ifdef HAVE_HDF5
 
-void j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata)
+void
+j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata)
 {
-    const gchar* name = udata;
+	const gchar* name = udata;
 
-    *file = H5Fcreate(name, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+	*file = H5Fcreate(name, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 }
 
-void j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata)
+void
+j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata)
 {
-    const gchar* name = udata;
-    H5Fclose(*file);
-    H5Fdelete(name, H5P_DEFAULT);
+	const gchar* name = udata;
+	H5Fclose(*file);
+	H5Fdelete(name, H5P_DEFAULT);
 }
 
 #endif

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -1,0 +1,38 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2018-2019 Johannes Coym
+ * Copyright (C) 2019-2021 Michael Kuhn
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#include "hdf-helper.h"
+
+#ifdef HAVE_HDF5
+
+void j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata)
+{
+    
+}
+
+void j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata)
+{
+    
+}
+
+#endif

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -27,12 +27,16 @@
 
 void j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata)
 {
-    
+    (void) udata;
+
+    *file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 }
 
 void j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata)
 {
-    
+    (void) udata;
+    H5Fclose(*file);
+    H5Fdelete("test_file.h5", H5P_DEFAULT);
 }
 
 #endif

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -36,7 +36,7 @@ void j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata)
 {
     const gchar* name = udata;
     H5Fclose(*file);
-    //H5Fdelete(name, H5P_DEFAULT);
+    H5Fdelete(name, H5P_DEFAULT);
 }
 
 #endif

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -28,17 +28,25 @@
 void
 j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata)
 {
-	const gchar* name = udata;
+	if (g_test_subprocess())
+	{
+		const gchar* name = udata;
 
-	*file = H5Fcreate(name, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+		*file = H5Fcreate(name, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+	}
 }
 
 void
 j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata)
 {
-	const gchar* name = udata;
-	H5Fclose(*file);
-	H5Fdelete(name, H5P_DEFAULT);
+	if (g_test_subprocess())
+	{
+		(void)udata;
+		H5Fclose(*file);
+		/// \todo Delete is not yet implemented
+		// const gchar* name = udata;
+		// H5Fdelete(name, H5P_DEFAULT);
+	}
 }
 
 #endif

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -29,6 +29,8 @@ void j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata)
 {
     (void) udata;
 
+    //*file = g_malloc(sizeof(hid_t));
+
     *file = H5Fcreate("test_file.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 }
 
@@ -37,6 +39,8 @@ void j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata)
     (void) udata;
     H5Fclose(*file);
     H5Fdelete("test_file.h5", H5P_DEFAULT);
+
+    //g_free(*file);
 }
 
 #endif

--- a/test/hdf5/hdf-helper.h
+++ b/test/hdf5/hdf-helper.h
@@ -1,7 +1,6 @@
 /*
  * JULEA - Flexible storage framework
- * Copyright (C) 2018-2019 Johannes Coym
- * Copyright (C) 2019-2021 Michael Kuhn
+ * Copyright (C) 2021 Timm Leon Erxleben
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/test/hdf5/hdf-helper.h
+++ b/test/hdf5/hdf-helper.h
@@ -1,0 +1,58 @@
+/*
+ * JULEA - Flexible storage framework
+ * Copyright (C) 2018-2019 Johannes Coym
+ * Copyright (C) 2019-2021 Michael Kuhn
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ **/
+
+#include <julea-config.h>
+
+#include <glib.h>
+
+#include <julea.h>
+
+#include "test.h"
+
+#ifdef HAVE_HDF5
+
+#include <julea-hdf5.h>
+
+#include <hdf5.h>
+
+/**
+ * Create a simple HDF5 file to test groups, datasets, ...
+ * 
+ * \internal
+ * 
+ * \param file File to be created.
+ * \param udata User specified data. Will be ignored.
+ **/
+void j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata);
+
+/**
+ * Teardown function for \ref j_test_hdf_file_fixture_setup
+ * 
+ * \internal
+ * 
+ * \param file File to delete.
+ * \param udata User specified data. Will be ignored.
+ **/
+void j_test_hdf_file_fixture_teardown(hid_t* file, gconstpointer udata);
+
+#endif

--- a/test/hdf5/hdf-helper.h
+++ b/test/hdf5/hdf-helper.h
@@ -37,9 +37,9 @@
 
 /**
  * Create a simple HDF5 file to test groups, datasets, ...
- * 
+ *
  * \internal
- * 
+ *
  * \param file File to be created.
  * \param udata User specified data. Will be ignored.
  **/
@@ -47,9 +47,9 @@ void j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata);
 
 /**
  * Teardown function for \ref j_test_hdf_file_fixture_setup
- * 
+ *
  * \internal
- * 
+ *
  * \param file File to delete.
  * \param udata User specified data. Will be ignored.
  **/

--- a/test/hdf5/hdf.c
+++ b/test/hdf5/hdf.c
@@ -237,7 +237,7 @@ test_hdf_hdf(void)
 	}
 
 	g_test_add_func("/hdf5/read_write", test_hdf_read_write);
-	g_test_add_func("/hdf5/dataset/create", test_hdf_dataset_create);
-	g_test_add_func("/hdf5/dataset/write", test_hdf_dataset_write);
+	g_test_add_func("/hdf5/dataset-create", test_hdf_dataset_create);
+	g_test_add_func("/hdf5/dataset-write", test_hdf_dataset_write);
 #endif
 }

--- a/test/test.c
+++ b/test/test.c
@@ -78,6 +78,7 @@ main(int argc, char** argv)
 	test_hdf_datatype();
 	test_hdf_file();
 	test_hdf_dataset();
+	test_hdf_group_link();
 
 	ret = g_test_run();
 

--- a/test/test.c
+++ b/test/test.c
@@ -76,6 +76,7 @@ main(int argc, char** argv)
 	// HDF5 client
 	test_hdf_hdf();
 	test_hdf_datatype();
+	test_hdf_file();
 
 	ret = g_test_run();
 

--- a/test/test.c
+++ b/test/test.c
@@ -75,6 +75,7 @@ main(int argc, char** argv)
 
 	// HDF5 client
 	test_hdf_hdf();
+	test_hdf_datatype();
 
 	ret = g_test_run();
 

--- a/test/test.c
+++ b/test/test.c
@@ -77,6 +77,7 @@ main(int argc, char** argv)
 	test_hdf_hdf();
 	test_hdf_datatype();
 	test_hdf_file();
+	test_hdf_dataset();
 
 	ret = g_test_run();
 

--- a/test/test.c
+++ b/test/test.c
@@ -79,6 +79,7 @@ main(int argc, char** argv)
 	test_hdf_file();
 	test_hdf_dataset();
 	test_hdf_group_link();
+	test_hdf_attribute();
 
 	ret = g_test_run();
 

--- a/test/test.h
+++ b/test/test.h
@@ -61,5 +61,6 @@ void test_item_uri(void);
 void test_hdf_hdf(void);
 void test_hdf_datatype(void);
 void test_hdf_file(void);
+void test_hdf_dataset(void);
 
 #endif

--- a/test/test.h
+++ b/test/test.h
@@ -63,5 +63,6 @@ void test_hdf_datatype(void);
 void test_hdf_file(void);
 void test_hdf_dataset(void);
 void test_hdf_group_link(void);
+void test_hdf_attribute(void);
 
 #endif

--- a/test/test.h
+++ b/test/test.h
@@ -59,5 +59,6 @@ void test_item_item_iterator(void);
 void test_item_uri(void);
 
 void test_hdf_hdf(void);
+void test_hdf_datatype(void);
 
 #endif

--- a/test/test.h
+++ b/test/test.h
@@ -60,5 +60,6 @@ void test_item_uri(void);
 
 void test_hdf_hdf(void);
 void test_hdf_datatype(void);
+void test_hdf_file(void);
 
 #endif

--- a/test/test.h
+++ b/test/test.h
@@ -62,5 +62,6 @@ void test_hdf_hdf(void);
 void test_hdf_datatype(void);
 void test_hdf_file(void);
 void test_hdf_dataset(void);
+void test_hdf_group_link(void);
 
 #endif


### PR DESCRIPTION
Just a draft for now I will update the PR for use with meson tests.
Test cases for all major hdf5 modules are included.

Originally I wanted to include H5LT but the low level test cases seem to cover it already.