### PR TITLE
Refactor julea-db

### DIFF
--- a/benchmark/hdf5/hdf.c
+++ b/benchmark/hdf5/hdf.c
@@ -180,7 +180,7 @@ create_dataset(hid_t file, gchar const* name, guint dimensions, hid_t* dataspace
 	dataspace = H5Screate_simple(dimensions, dims, NULL);
 	dataset = H5Dcreate2(file, name, H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-	// FIXME julea-db: if we try to write to a dataset with a closed dataspace, errors occur
+	/// \todo julea-db: if we try to write to a dataset with a closed dataspace, errors occur
 	if (dataspace_out != NULL)
 	{
 		*dataspace_out = dataspace;

--- a/lib/hdf5-db/jhdf5-db-attr.c
+++ b/lib/hdf5-db/jhdf5-db-attr.c
@@ -42,9 +42,9 @@
 
 #include "jhdf5-db.h"
 
-static JDBSchema* julea_db_schema_attr = NULL;
+JDBSchema* julea_db_schema_attr = NULL;
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_term(void)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -58,7 +58,7 @@ H5VL_julea_db_attr_term(void)
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_init(hid_t vipl_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -149,7 +149,7 @@ H5VL_julea_db_attr_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-				// FIXME Use same key type for every db backend to remove get for every new schema.
+				/// \todo Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_attr, batch, &error))
 				{
 					j_goto_error();
@@ -181,7 +181,7 @@ _error:
 	return 1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_truncate_file(void* obj)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -236,7 +236,7 @@ _error:
 	return 1;
 }
 
-static void*
+void*
 H5VL_julea_db_attr_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t type_id, hid_t space_id, hid_t acpl_id, hid_t aapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -364,7 +364,7 @@ _error:
 	return NULL;
 }
 
-static void*
+void*
 H5VL_julea_db_attr_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t aapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -489,7 +489,7 @@ _error:
 	return NULL;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_read(void* obj, hid_t mem_type_id, void* buf, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -550,7 +550,7 @@ _error:
 	return 1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_write(void* obj, hid_t mem_type_id, const void* buf, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -624,7 +624,7 @@ _error:
 	return 1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_get(void* obj, H5VL_attr_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -655,7 +655,7 @@ H5VL_julea_db_attr_get(void* obj, H5VL_attr_get_t get_type, hid_t dxpl_id, void*
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_specific(void* obj, const H5VL_loc_params_t* loc_params, H5VL_attr_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -670,11 +670,11 @@ H5VL_julea_db_attr_specific(void* obj, const H5VL_loc_params_t* loc_params, H5VL
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_ATTR, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_optional(void* obj, H5VL_attr_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -688,11 +688,11 @@ H5VL_julea_db_attr_optional(void* obj, H5VL_attr_optional_t opt_type, hid_t dxpl
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_ATTR, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_attr_close(void* obj, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);

--- a/lib/hdf5-db/jhdf5-db-dataset.c
+++ b/lib/hdf5-db/jhdf5-db-dataset.c
@@ -42,9 +42,9 @@
 
 #include "jhdf5-db.h"
 
-static JDBSchema* julea_db_schema_dataset = NULL;
+JDBSchema* julea_db_schema_dataset = NULL;
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_term(void)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -58,7 +58,7 @@ H5VL_julea_db_dataset_term(void)
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_init(hid_t vipl_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -164,7 +164,7 @@ H5VL_julea_db_dataset_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-				// FIXME Use same key type for every db backend to remove get for every new schema.
+				/// \todo Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_dataset, batch, &error))
 				{
 					j_goto_error();
@@ -196,7 +196,7 @@ _error:
 	return 1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_truncate_file(void* obj)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -251,7 +251,7 @@ _error:
 	return 1;
 }
 
-static void*
+void*
 H5VL_julea_db_dataset_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t lcpl_id, hid_t type_id, hid_t space_id, hid_t dcpl_id, hid_t dapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -404,7 +404,7 @@ _error:
 	return NULL;
 }
 
-static void*
+void*
 H5VL_julea_db_dataset_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t dapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -896,7 +896,7 @@ calculate_statistics(JHDF5Object_t* object, const void* buf, gsize bytes, hid_t 
 	}
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_write(void* obj, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id, hid_t xfer_plist_id, const void* buf, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -995,7 +995,7 @@ _error:
 	return 1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_read(void* obj, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id, hid_t xfer_plist_id, void* buf, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1099,7 +1099,7 @@ _error:
 	return 1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_get(void* obj, H5VL_dataset_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1130,7 +1130,7 @@ H5VL_julea_db_dataset_get(void* obj, H5VL_dataset_get_t get_type, hid_t dxpl_id,
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_specific(void* obj, H5VL_dataset_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1144,11 +1144,11 @@ H5VL_julea_db_dataset_specific(void* obj, H5VL_dataset_specific_t specific_type,
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_DATASET, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_optional(void* obj, H5VL_dataset_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1162,11 +1162,11 @@ H5VL_julea_db_dataset_optional(void* obj, H5VL_dataset_optional_t opt_type, hid_
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_DATASET, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_dataset_close(void* obj, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);

--- a/lib/hdf5-db/jhdf5-db-datatype.c
+++ b/lib/hdf5-db/jhdf5-db-datatype.c
@@ -42,7 +42,7 @@
 
 #include "jhdf5-db.h"
 
-static JDBSchema* julea_db_schema_datatype_header = NULL;
+JDBSchema* julea_db_schema_datatype_header = NULL;
 
 static const void*
 H5VL_julea_db_datatype_convert_type_change(hid_t type_id_from, hid_t type_id_to, const char* from_buf, char* target_buf, guint count)
@@ -82,7 +82,7 @@ H5VL_julea_db_datatype_convert_type_change(hid_t type_id_from, hid_t type_id_to,
 	return target_buf;
 }
 
-static const void*
+const void*
 H5VL_julea_db_datatype_convert_type(hid_t type_id_from, hid_t type_id_to, const char* from_buf, char* tmp_buf, guint count)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -95,7 +95,7 @@ H5VL_julea_db_datatype_convert_type(hid_t type_id_from, hid_t type_id_to, const 
 	return H5VL_julea_db_datatype_convert_type_change(type_id_from, type_id_to, from_buf, tmp_buf, count);
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_datatype_term(void)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -109,7 +109,7 @@ H5VL_julea_db_datatype_term(void)
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_datatype_init(hid_t vipl_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -228,7 +228,7 @@ H5VL_julea_db_datatype_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-				// FIXME Use same key type for every db backend to remove get for every new schema.
+				/// \todo Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_datatype_header, batch, &error))
 				{
 					j_goto_error();
@@ -261,7 +261,7 @@ _error:
 	return 1;
 }
 
-static JHDF5Object_t*
+JHDF5Object_t*
 H5VL_julea_db_datatype_decode(void* backend_id, guint64 backend_id_len)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -333,7 +333,7 @@ _error:
 	return NULL;
 }
 
-static JHDF5Object_t*
+JHDF5Object_t*
 H5VL_julea_db_datatype_encode(hid_t* type_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -529,7 +529,7 @@ _error:
 	return NULL;
 }
 
-static void*
+void*
 H5VL_julea_db_datatype_commit(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t type_id, hid_t lcpl_id, hid_t tcpl_id, hid_t tapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -544,11 +544,11 @@ H5VL_julea_db_datatype_commit(void* obj, const H5VL_loc_params_t* loc_params, co
 	(void)dxpl_id;
 	(void)req;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return NULL;
 }
 
-static void*
+void*
 H5VL_julea_db_datatype_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t tapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -560,11 +560,11 @@ H5VL_julea_db_datatype_open(void* obj, const H5VL_loc_params_t* loc_params, cons
 	(void)dxpl_id;
 	(void)req;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return NULL;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_datatype_get(void* obj, H5VL_datatype_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -575,11 +575,11 @@ H5VL_julea_db_datatype_get(void* obj, H5VL_datatype_get_t get_type, hid_t dxpl_i
 	(void)req;
 	(void)arguments;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_datatype_specific(void* obj, H5VL_datatype_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -590,11 +590,11 @@ H5VL_julea_db_datatype_specific(void* obj, H5VL_datatype_specific_t specific_typ
 	(void)req;
 	(void)arguments;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_datatype_optional(void* obj, H5VL_datatype_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -605,11 +605,11 @@ H5VL_julea_db_datatype_optional(void* obj, H5VL_datatype_optional_t opt_type, hi
 	(void)req;
 	(void)arguments;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_datatype_close(void* dt, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -618,6 +618,6 @@ H5VL_julea_db_datatype_close(void* dt, hid_t dxpl_id, void** req)
 	(void)dxpl_id;
 	(void)req;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -42,9 +42,9 @@
 
 #include "jhdf5-db.h"
 
-static JDBSchema* julea_db_schema_file = NULL;
+JDBSchema* julea_db_schema_file = NULL;
 
-static herr_t
+herr_t
 H5VL_julea_db_file_term(void)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -58,7 +58,7 @@ H5VL_julea_db_file_term(void)
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_file_init(hid_t vipl_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -134,7 +134,7 @@ H5VL_julea_db_file_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-				// FIXME Use same key type for every db backend to remove get for every new schema.
+				/// \todo Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_file, batch, &error))
 				{
 					j_goto_error();
@@ -169,7 +169,7 @@ _error:
 	return 1;
 }
 
-static void*
+void*
 H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -311,7 +311,7 @@ _error:
 	return NULL;
 }
 
-static void*
+void*
 H5VL_julea_db_file_open(const char* name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -381,7 +381,7 @@ _error:
 	return NULL;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_file_get(void* obj, H5VL_file_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -395,11 +395,11 @@ H5VL_julea_db_file_get(void* obj, H5VL_file_get_t get_type, hid_t dxpl_id, void*
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_FILE, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_file_specific(void* obj, H5VL_file_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -413,11 +413,11 @@ H5VL_julea_db_file_specific(void* obj, H5VL_file_specific_t specific_type, hid_t
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_FILE, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_file_optional(void* obj, H5VL_file_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -431,11 +431,11 @@ H5VL_julea_db_file_optional(void* obj, H5VL_file_optional_t opt_type, hid_t dxpl
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_FILE, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_file_close(void* obj, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);

--- a/lib/hdf5-db/jhdf5-db-group.c
+++ b/lib/hdf5-db/jhdf5-db-group.c
@@ -42,9 +42,9 @@
 
 #include "jhdf5-db.h"
 
-static JDBSchema* julea_db_schema_group = NULL;
+JDBSchema* julea_db_schema_group = NULL;
 
-static herr_t
+herr_t
 H5VL_julea_db_group_term(void)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -58,7 +58,7 @@ H5VL_julea_db_group_term(void)
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_group_init(hid_t vipl_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -134,7 +134,7 @@ H5VL_julea_db_group_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-				// FIXME Use same key type for every db backend to remove get for every new schema.
+				/// \todo Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_group, batch, &error))
 				{
 					j_goto_error();
@@ -166,7 +166,7 @@ _error:
 	return 1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_group_truncate_file(void* obj)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -221,7 +221,7 @@ _error:
 	return 1;
 }
 
-static void*
+void*
 H5VL_julea_db_group_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -324,7 +324,7 @@ _error:
 	return NULL;
 }
 
-static void*
+void*
 H5VL_julea_db_group_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t gapl_id, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -397,7 +397,7 @@ _error:
 	return NULL;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_group_get(void* obj, H5VL_group_get_t get_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -411,11 +411,11 @@ H5VL_julea_db_group_get(void* obj, H5VL_group_get_t get_type, hid_t dxpl_id, voi
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_GROUP, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_group_specific(void* obj, H5VL_group_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -429,11 +429,11 @@ H5VL_julea_db_group_specific(void* obj, H5VL_group_specific_t specific_type, hid
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_GROUP, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_group_optional(void* obj, H5VL_group_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -447,11 +447,11 @@ H5VL_julea_db_group_optional(void* obj, H5VL_group_optional_t opt_type, hid_t dx
 
 	g_return_val_if_fail(object->type == J_HDF5_OBJECT_TYPE_GROUP, 1);
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_group_close(void* obj, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);

--- a/lib/hdf5-db/jhdf5-db-link.c
+++ b/lib/hdf5-db/jhdf5-db-link.c
@@ -42,9 +42,9 @@
 
 #include "jhdf5-db.h"
 
-static JDBSchema* julea_db_schema_link = NULL;
+JDBSchema* julea_db_schema_link = NULL;
 
-static herr_t
+herr_t
 H5VL_julea_db_link_term(void)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -58,7 +58,7 @@ H5VL_julea_db_link_term(void)
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_link_init(hid_t vipl_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -173,7 +173,7 @@ H5VL_julea_db_link_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-				// FIXME Use same key type for every db backend to remove get for every new schema.
+				/// \todo Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_link, batch, &error))
 				{
 					j_goto_error();
@@ -205,7 +205,7 @@ _error:
 	return 1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_link_truncate_file(void* obj)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -260,7 +260,7 @@ _error:
 	return 1;
 }
 
-static gboolean
+gboolean
 H5VL_julea_db_link_get_helper(JHDF5Object_t* parent, JHDF5Object_t* child, const char* name)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -364,7 +364,7 @@ _error:
 	return FALSE;
 }
 
-static gboolean
+gboolean
 H5VL_julea_db_link_create_helper(JHDF5Object_t* parent, JHDF5Object_t* child, const char* name)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -511,7 +511,7 @@ _error:
 	return FALSE;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_link_create(H5VL_link_create_type_t create_type, void* obj, const H5VL_loc_params_t* loc_params, hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void** req, va_list argumenmts)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -525,11 +525,11 @@ H5VL_julea_db_link_create(H5VL_link_create_type_t create_type, void* obj, const 
 	(void)req;
 	(void)argumenmts;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_link_copy(void* src_obj, const H5VL_loc_params_t* loc_params1, void* dst_obj, const H5VL_loc_params_t* loc_params2, hid_t lcpl, hid_t lapl, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -543,11 +543,11 @@ H5VL_julea_db_link_copy(void* src_obj, const H5VL_loc_params_t* loc_params1, voi
 	(void)dxpl_id;
 	(void)req;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_link_move(void* src_obj, const H5VL_loc_params_t* loc_params1, void* dst_obj, const H5VL_loc_params_t* loc_params2, hid_t lcpl, hid_t lapl, hid_t dxpl_id, void** req)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -561,11 +561,11 @@ H5VL_julea_db_link_move(void* src_obj, const H5VL_loc_params_t* loc_params1, voi
 	(void)dxpl_id;
 	(void)req;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_link_get(void* obj, const H5VL_loc_params_t* loc_params, H5VL_link_get_t get_type,
 		       hid_t dxpl_id, void** req, va_list arguments)
 {
@@ -578,10 +578,11 @@ H5VL_julea_db_link_get(void* obj, const H5VL_loc_params_t* loc_params, H5VL_link
 	(void)req;
 	(void)arguments;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
-static herr_t
+
+herr_t
 H5VL_julea_db_link_specific(void* obj, const H5VL_loc_params_t* loc_params, H5VL_link_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -593,11 +594,11 @@ H5VL_julea_db_link_specific(void* obj, const H5VL_loc_params_t* loc_params, H5VL
 	(void)req;
 	(void)arguments;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_link_optional(void* obj, H5VL_link_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -608,6 +609,6 @@ H5VL_julea_db_link_optional(void* obj, H5VL_link_optional_t opt_type, hid_t dxpl
 	(void)req;
 	(void)arguments;
 
-	g_critical("%s NOT implemented !!", G_STRLOC);
-	g_assert_not_reached();
+	g_warning("%s called but not implemented!", __func__);
+	return -1;
 }

--- a/lib/hdf5-db/jhdf5-db-shared.c
+++ b/lib/hdf5-db/jhdf5-db-shared.c
@@ -42,7 +42,7 @@
 
 #include "jhdf5-db.h"
 
-static char*
+char*
 H5VL_julea_db_buf_to_hex(const char* prefix, const char* buf, guint buf_len)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -68,7 +68,7 @@ H5VL_julea_db_buf_to_hex(const char* prefix, const char* buf, guint buf_len)
 	return str;
 }
 
-static void
+void
 H5VL_julea_db_error_handler(GError* error)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -79,7 +79,7 @@ H5VL_julea_db_error_handler(GError* error)
 	}
 }
 
-static JHDF5Object_t*
+JHDF5Object_t*
 H5VL_julea_db_object_ref(JHDF5Object_t* object)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -91,7 +91,7 @@ H5VL_julea_db_object_ref(JHDF5Object_t* object)
 	return object;
 }
 
-static JHDF5Object_t*
+JHDF5Object_t*
 H5VL_julea_db_object_new(JHDF5ObjectType type)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -109,7 +109,7 @@ H5VL_julea_db_object_new(JHDF5ObjectType type)
 	return object;
 }
 
-static void
+void
 H5VL_julea_db_object_unref(JHDF5Object_t* object)
 {
 	J_TRACE_FUNCTION(NULL);

--- a/lib/hdf5-db/jhdf5-db-space.c
+++ b/lib/hdf5-db/jhdf5-db-space.c
@@ -42,10 +42,10 @@
 
 #include "jhdf5-db.h"
 
-static JDBSchema* julea_db_schema_space_header = NULL;
-static JDBSchema* julea_db_schema_space = NULL;
+JDBSchema* julea_db_schema_space_header = NULL;
+JDBSchema* julea_db_schema_space = NULL;
 
-static herr_t
+herr_t
 H5VL_julea_db_space_term(void)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -65,7 +65,7 @@ H5VL_julea_db_space_term(void)
 	return 0;
 }
 
-static herr_t
+herr_t
 H5VL_julea_db_space_init(hid_t vipl_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -139,7 +139,7 @@ H5VL_julea_db_space_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-				// FIXME Use same key type for every db backend to remove get for every new schema.
+				/// \todo Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_space_header, batch, &error))
 				{
 					j_goto_error();
@@ -222,7 +222,7 @@ H5VL_julea_db_space_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-				// FIXME Use same key type for every db backend to remove get for every new schema.
+				/// \todo Use same key type for every db backend to remove get for every new schema.
 				if (!j_db_schema_get(julea_db_schema_space, batch, &error))
 				{
 					j_goto_error();
@@ -255,7 +255,7 @@ _error:
 	return 1;
 }
 
-static JHDF5Object_t*
+JHDF5Object_t*
 H5VL_julea_db_space_decode(void* backend_id, guint64 backend_id_len)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -323,7 +323,7 @@ _error:
 	return NULL;
 }
 
-static JHDF5Object_t*
+JHDF5Object_t*
 H5VL_julea_db_space_encode(hid_t* type_id)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -377,7 +377,7 @@ H5VL_julea_db_space_encode(hid_t* type_id)
 
 	{
 		J_TRACE("H5SencodeNULL", 0);
-		H5Sencode(*type_id, NULL, &size);
+		H5Sencode1(*type_id, NULL, &size);
 	}
 
 	if (!(object->space.data = g_new(char, size)))
@@ -387,7 +387,7 @@ H5VL_julea_db_space_encode(hid_t* type_id)
 
 	{
 		J_TRACE("H5Sencode", 0);
-		H5Sencode(*type_id, object->space.data, &size);
+		H5Sencode1(*type_id, object->space.data, &size);
 	}
 
 	object->space.hdf5_id = *type_id;

--- a/lib/hdf5-db/jhdf5-db.c
+++ b/lib/hdf5-db/jhdf5-db.c
@@ -45,33 +45,6 @@
 
 #include "jhdf5-db.h"
 
-static herr_t H5VL_julea_db_attr_init(hid_t vipl_id);
-static herr_t H5VL_julea_db_attr_term(void);
-static herr_t H5VL_julea_db_dataset_init(hid_t vipl_id);
-static herr_t H5VL_julea_db_dataset_term(void);
-static herr_t H5VL_julea_db_datatype_init(hid_t vipl_id);
-static herr_t H5VL_julea_db_datatype_term(void);
-static herr_t H5VL_julea_db_file_init(hid_t vipl_id);
-static herr_t H5VL_julea_db_file_term(void);
-static herr_t H5VL_julea_db_group_init(hid_t vipl_id);
-static herr_t H5VL_julea_db_group_term(void);
-static herr_t H5VL_julea_db_space_init(hid_t vipl_id);
-static herr_t H5VL_julea_db_space_term(void);
-static herr_t H5VL_julea_db_link_init(hid_t vipl_id);
-static herr_t H5VL_julea_db_link_term(void);
-
-#include "jhdf5-db.h"
-
-/// \todo order is important
-#include "jhdf5-db-shared.c"
-#include "jhdf5-db-link.c"
-#include "jhdf5-db-group.c"
-#include "jhdf5-db-datatype.c"
-#include "jhdf5-db-space.c"
-#include "jhdf5-db-attr.c"
-#include "jhdf5-db-dataset.c"
-#include "jhdf5-db-file.c"
-
 #define _GNU_SOURCE
 
 #define JULEA_DB 530

--- a/lib/hdf5-db/jhdf5-db.h
+++ b/lib/hdf5-db/jhdf5-db.h
@@ -112,7 +112,6 @@ extern JDBSchema* julea_db_schema_link;
 extern JDBSchema* julea_db_schema_space_header;
 extern JDBSchema* julea_db_schema_space;
 
-
 /* init and term functions */
 
 herr_t H5VL_julea_db_attr_init(hid_t vipl_id);

--- a/lib/hdf5-db/jhdf5-db.h
+++ b/lib/hdf5-db/jhdf5-db.h
@@ -20,10 +20,10 @@
  * \file
  **/
 
+/// \todo add documentation
+
 #ifndef H5VL_JULEA_DB_H
 #define H5VL_JULEA_DB_H
-
-#define H5Sencode_vers 1
 
 #include <hdf5.h>
 #include <H5PLextern.h>
@@ -101,19 +101,116 @@ struct JHDF5Object_t
 	};
 };
 
-/*internal helper functions*/
+/* db schemas */
 
-static void
-H5VL_julea_db_error_handler(GError* error);
-static char*
-H5VL_julea_db_buf_to_hex(const char* prefix, const char* buf, guint buf_len);
+extern JDBSchema* julea_db_schema_attr;
+extern JDBSchema* julea_db_schema_dataset;
+extern JDBSchema* julea_db_schema_datatype_header;
+extern JDBSchema* julea_db_schema_file;
+extern JDBSchema* julea_db_schema_group;
+extern JDBSchema* julea_db_schema_link;
+extern JDBSchema* julea_db_schema_space_header;
+extern JDBSchema* julea_db_schema_space;
 
-static JHDF5Object_t*
-H5VL_julea_db_object_new(JHDF5ObjectType type);
-static JHDF5Object_t*
-H5VL_julea_db_object_ref(JHDF5Object_t* object);
-static void
-H5VL_julea_db_object_unref(JHDF5Object_t* object);
+
+/* init and term functions */
+
+herr_t H5VL_julea_db_attr_init(hid_t vipl_id);
+herr_t H5VL_julea_db_attr_term(void);
+herr_t H5VL_julea_db_dataset_init(hid_t vipl_id);
+herr_t H5VL_julea_db_dataset_term(void);
+herr_t H5VL_julea_db_datatype_init(hid_t vipl_id);
+herr_t H5VL_julea_db_datatype_term(void);
+herr_t H5VL_julea_db_file_init(hid_t vipl_id);
+herr_t H5VL_julea_db_file_term(void);
+herr_t H5VL_julea_db_group_init(hid_t vipl_id);
+herr_t H5VL_julea_db_group_term(void);
+herr_t H5VL_julea_db_link_init(hid_t vipl_id);
+herr_t H5VL_julea_db_link_term(void);
+herr_t H5VL_julea_db_space_init(hid_t vipl_id);
+herr_t H5VL_julea_db_space_term(void);
+
+/* VOL callbacks */
+
+// attribute
+void* H5VL_julea_db_attr_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t type_id, hid_t space_id, hid_t acpl_id, hid_t aapl_id, hid_t dxpl_id, void** req);
+void* H5VL_julea_db_attr_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t aapl_id, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_attr_read(void* obj, hid_t mem_type_id, void* buf, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_attr_write(void* obj, hid_t mem_type_id, const void* buf, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_attr_get(void* obj, H5VL_attr_get_t get_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_attr_specific(void* obj, const H5VL_loc_params_t* loc_params, H5VL_attr_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_attr_optional(void* obj, H5VL_attr_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_attr_close(void* obj, hid_t dxpl_id, void** req);
+
+// dataset
+void* H5VL_julea_db_dataset_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t lcpl_id, hid_t type_id, hid_t space_id, hid_t dcpl_id, hid_t dapl_id, hid_t dxpl_id, void** req);
+void* H5VL_julea_db_dataset_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t dapl_id, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_dataset_write(void* obj, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id, hid_t xfer_plist_id, const void* buf, void** req);
+herr_t H5VL_julea_db_dataset_read(void* obj, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id, hid_t xfer_plist_id, void* buf, void** req);
+herr_t H5VL_julea_db_dataset_get(void* obj, H5VL_dataset_get_t get_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_dataset_specific(void* obj, H5VL_dataset_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_dataset_optional(void* obj, H5VL_dataset_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_dataset_close(void* obj, hid_t dxpl_id, void** req);
+
+// datatype
+void* H5VL_julea_db_datatype_commit(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t type_id, hid_t lcpl_id, hid_t tcpl_id, hid_t tapl_id, hid_t dxpl_id, void** req);
+void* H5VL_julea_db_datatype_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t tapl_id, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_datatype_get(void* obj, H5VL_datatype_get_t get_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_datatype_specific(void* obj, H5VL_datatype_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_datatype_optional(void* obj, H5VL_datatype_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_datatype_close(void* dt, hid_t dxpl_id, void** req);
+
+// file
+void* H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void** req);
+void* H5VL_julea_db_file_open(const char* name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_file_get(void* obj, H5VL_file_get_t get_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_file_specific(void* obj, H5VL_file_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_file_optional(void* obj, H5VL_file_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_file_close(void* obj, hid_t dxpl_id, void** req);
+
+// group
+void* H5VL_julea_db_group_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id, hid_t dxpl_id, void** req);
+void* H5VL_julea_db_group_open(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t gapl_id, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_group_get(void* obj, H5VL_group_get_t get_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_group_specific(void* obj, H5VL_group_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_group_optional(void* obj, H5VL_group_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_group_close(void* obj, hid_t dxpl_id, void** req);
+
+// link
+herr_t H5VL_julea_db_link_create(H5VL_link_create_type_t create_type, void* obj, const H5VL_loc_params_t* loc_params, hid_t lcpl_id, hid_t lapl_id, hid_t dxpl_id, void** req, va_list argumenmts);
+herr_t H5VL_julea_db_link_copy(void* src_obj, const H5VL_loc_params_t* loc_params1, void* dst_obj, const H5VL_loc_params_t* loc_params2, hid_t lcpl, hid_t lapl, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_link_move(void* src_obj, const H5VL_loc_params_t* loc_params1, void* dst_obj, const H5VL_loc_params_t* loc_params2, hid_t lcpl, hid_t lapl, hid_t dxpl_id, void** req);
+herr_t H5VL_julea_db_link_get(void* obj, const H5VL_loc_params_t* loc_params, H5VL_link_get_t get_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_link_specific(void* obj, const H5VL_loc_params_t* loc_params, H5VL_link_specific_t specific_type, hid_t dxpl_id, void** req, va_list arguments);
+herr_t H5VL_julea_db_link_optional(void* obj, H5VL_link_optional_t opt_type, hid_t dxpl_id, void** req, va_list arguments);
+
+/* internal helper functions */
+
+void H5VL_julea_db_error_handler(GError* error);
+char* H5VL_julea_db_buf_to_hex(const char* prefix, const char* buf, guint buf_len);
+
+JHDF5Object_t* H5VL_julea_db_object_new(JHDF5ObjectType type);
+JHDF5Object_t* H5VL_julea_db_object_ref(JHDF5Object_t* object);
+void H5VL_julea_db_object_unref(JHDF5Object_t* object);
+
+// truncate
+herr_t H5VL_julea_db_link_truncate_file(void* obj);
+herr_t H5VL_julea_db_attr_truncate_file(void* obj);
+herr_t H5VL_julea_db_dataset_truncate_file(void* obj);
+herr_t H5VL_julea_db_group_truncate_file(void* obj);
+
+// datatype helper
+const void* H5VL_julea_db_datatype_convert_type(hid_t type_id_from, hid_t type_id_to, const char* from_buf, char* tmp_buf, guint count);
+JHDF5Object_t* H5VL_julea_db_datatype_decode(void* backend_id, guint64 backend_id_len);
+JHDF5Object_t* H5VL_julea_db_datatype_encode(hid_t* type_id);
+
+// space helper
+JHDF5Object_t* H5VL_julea_db_space_decode(void* backend_id, guint64 backend_id_len);
+JHDF5Object_t* H5VL_julea_db_space_encode(hid_t* type_id);
+
+// link helper
+gboolean H5VL_julea_db_link_get_helper(JHDF5Object_t* parent, JHDF5Object_t* child, const char* name);
+gboolean H5VL_julea_db_link_create_helper(JHDF5Object_t* parent, JHDF5Object_t* child, const char* name);
 
 #define j_goto_error() \
 	do \

--- a/meson.build
+++ b/meson.build
@@ -447,6 +447,15 @@ if hdf_dep.found()
 		]),
 		'hdf5-db': files([
 			'lib/hdf5-db/jhdf5-db.c',
+			'lib/hdf5-db/jhdf5-db-attr.c',
+			'lib/hdf5-db/jhdf5-db-dataset.c',
+			'lib/hdf5-db/jhdf5-db-datatype.c',
+			'lib/hdf5-db/jhdf5-db-file.c',
+			'lib/hdf5-db/jhdf5-db-group.c',
+			'lib/hdf5-db/jhdf5-db-link.c',
+			'lib/hdf5-db/jhdf5-db-shared.c',
+			'lib/hdf5-db/jhdf5-db-space.c',
+
 		])
 	}
 

--- a/test/hdf5/hdf.c
+++ b/test/hdf5/hdf.c
@@ -212,7 +212,7 @@ test_hdf_dataset_write(void)
 		H5Dclose(dataset);
 	}
 
-	// FIXME julea-db has problems with this
+	/// \todo julea-db has problems with this
 	//dataset = H5Dcreate2(file, "dataset-write-closed-dataspace", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
 	H5Sclose(dataspace);


### PR DESCRIPTION
I refactored julea-db so that no *.c files need to be included anymore resolving this [todo](https://github.com/julea-io/julea/blob/28636db07d95d64759c1090fa4b857017f05ce03/lib/hdf5-db/jhdf5-db.c#L65).

On top of that julea-db is now more flexible for more VOL callbacks to be implementented because every module can access all db schemas. One example is the link iterate callback which needs to access encountered objects.

Some old FIXMEs are replaced by the new \todo