### PR TITLE
inlcude markdown files in doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,10 +1,10 @@
-# Doxyfile 1.9.1
+# Doxyfile 1.9.2
 
 #---------------------------------------------------------------------------
 # Project related configuration options
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
-PROJECT_NAME           = "JULEA"
+PROJECT_NAME           = JULEA
 PROJECT_NUMBER         =
 PROJECT_BRIEF          =
 PROJECT_LOGO           =
@@ -12,7 +12,6 @@ OUTPUT_DIRECTORY       =
 CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
-OUTPUT_TEXT_DIRECTION  = None
 BRIEF_MEMBER_DESC      = YES
 REPEAT_BRIEF           = YES
 ABBREVIATE_BRIEF       = "The $name class" \
@@ -82,6 +81,7 @@ INTERNAL_DOCS          = NO
 CASE_SENSE_NAMES       = YES
 HIDE_SCOPE_NAMES       = NO
 HIDE_COMPOUND_REFERENCE= NO
+SHOW_HEADERFILE        = YES
 SHOW_INCLUDE_FILES     = YES
 SHOW_GROUPED_MEMB_INC  = NO
 FORCE_LOCAL_INCLUDES   = NO
@@ -111,6 +111,7 @@ QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
 WARN_NO_PARAMDOC       = NO
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
@@ -119,7 +120,9 @@ WARN_LOGFILE           =
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                  = include \
-                         lib
+                         lib \
+                         doc \
+                         README.md
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \
@@ -179,7 +182,7 @@ INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS =
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = doc/README.md
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
 #---------------------------------------------------------------------------
@@ -192,10 +195,6 @@ REFERENCES_LINK_SOURCE = YES
 SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = YES
-CLANG_ASSISTED_PARSING = NO
-CLANG_ADD_INC_PATHS    = YES
-CLANG_OPTIONS          =
-CLANG_DATABASE_PATH    =
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
@@ -243,6 +242,7 @@ GENERATE_ECLIPSEHELP   = NO
 ECLIPSE_DOC_ID         = org.doxygen.Project
 DISABLE_INDEX          = NO
 GENERATE_TREEVIEW      = NO
+FULL_SIDEBAR           = NO
 ENUM_VALUES_PER_LINE   = 4
 TREEVIEW_WIDTH         = 250
 EXT_LINKS_IN_WINDOW    = NO
@@ -251,6 +251,7 @@ FORMULA_FONTSIZE       = 10
 FORMULA_TRANSPARENT    = YES
 FORMULA_MACROFILE      =
 USE_MATHJAX            = NO
+MATHJAX_VERSION        = MathJax_2
 MATHJAX_FORMAT         = HTML-CSS
 MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 MATHJAX_EXTENSIONS     =
@@ -281,7 +282,6 @@ PDF_HYPERLINKS         = YES
 USE_PDFLATEX           = YES
 LATEX_BATCHMODE        = NO
 LATEX_HIDE_INDICES     = NO
-LATEX_SOURCE_CODE      = NO
 LATEX_BIB_STYLE        = plain
 LATEX_TIMESTAMP        = NO
 LATEX_EMOJI_DIRECTORY  =
@@ -294,7 +294,6 @@ COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
 RTF_STYLESHEET_FILE    =
 RTF_EXTENSIONS_FILE    =
-RTF_SOURCE_CODE        = NO
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
 #---------------------------------------------------------------------------
@@ -315,7 +314,6 @@ XML_NS_MEMB_FILE_SCOPE = NO
 #---------------------------------------------------------------------------
 GENERATE_DOCBOOK       = NO
 DOCBOOK_OUTPUT         = docbook
-DOCBOOK_PROGRAMLISTING = NO
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
 #---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Its goal is to provide a solid foundation for storage research and teaching.
 For more information, please refer to the [documentation](doc/README.md).
 There is also a separate [API documentation](https://julea-io.github.io/julea/) available.
 
-## Quick Start
+## Quick Start {#QuickStart}
 
 To use JULEA, first clone the Git repository and enter the directory.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Its goal is to provide a solid foundation for storage research and teaching.
 For more information, please refer to the [documentation](doc/README.md).
 There is also a separate [API documentation](https://julea-io.github.io/julea/) available.
 
-## Quick Start {#QuickStart}
+## Quick Start
 
 To use JULEA, first clone the Git repository and enter the directory.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ Its goal is to provide a solid foundation for storage research and teaching.
 
 ## Links
 
-* [Quick Start](@ref QuickStart)
+* [QuilkStart](../README.md#quick-start-quickstart) [Quick Start](@ref QuickStart)
 * [Dependencies](dependencies.md)
 * [Installation and Usage](installation-usage.md)
 * [Configuration](configuration.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ Its goal is to provide a solid foundation for storage research and teaching.
 
 ## Links
 
-* [Quick Start](../README.md#quick-start)
+* [Quick Start](@ref QuickStart)
 * [Dependencies](dependencies.md)
 * [Installation and Usage](installation-usage.md)
 * [Configuration](configuration.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ Its goal is to provide a solid foundation for storage research and teaching.
 
 ## Links
 
-* [QuilkStart](../README.md#quick-start-quickstart) [Quick Start](@ref QuickStart)
+* [QuickStart](../README.md)
 * [Dependencies](dependencies.md)
 * [Installation and Usage](installation-usage.md)
 * [Configuration](configuration.md)

--- a/include/julea.h
+++ b/include/julea.h
@@ -24,8 +24,6 @@
 #define JULEA_H
 
 /**
- * \mainpage
- *
  * JULEA is a distributed file system with a newly designed application programming interface.
  * It also allows to change the file system semantics at runtime.
  *


### PR DESCRIPTION
The `Readme.md` and the `doc/*.md` files are new accessible from the Doxygen documentation.
`doc/Readme.md `is the new Doxygen main page.