### PR TITLE
Enchant the debugging capabilities

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -10,13 +10,17 @@ Moreover, developers should be aware of the fact that debug builds of JULEA can 
 JULEA contains a tracing component that can be used to record information about various aspects of JULEA's behavior.
 The overall tracing can be influenced using the `JULEA_TRACE` environment variable.
 If the variable is set to `echo`, all tracing information will be printed to stderr.
+If the variable is set to `summary`, the runtime and calls are added for each unique call stack.
 If JULEA has been built with OTF support, a value of `otf` will cause JULEA to produce traces via OTF.
 It is also possible to specify multiple values separated by commas.
 
 By default, all functions are traced.
 If this produces too much output, a filter can be set using the `JULEA_TRACE_FUNCTION` environment variable.
-The variable can contain a list of function wildcards that are separated by commas.
+The variable can contain a list of function matcher that are separated by commas.
 The wildcards support `*` and `?`.
+Filterung will remove call stacks from the `summary`,
+to keep the call stack do differ between different kind you can specify `KEEP_STACK` as matcher.
+You can also add matcher for top level functions you are interested in.
 
 ## Coverage
 


### PR DESCRIPTION
* add documentation for existing summary envs (`J_TRACE` and `J_TRACE_FUNCTION`)
* add `KEEP_STACK` as option for `J_TRACE_FUNCTION` to trace stacks below traced function 

 e.g.:  
`J_TRACE=summary J_TRACE_FUNCTION=j_message_send ./hello_world` → 
```
# stack duration[s] count
j_message_send 0.000237 8  
```

 `J_TRACE=summary J_TRACE_FUNCTION=j_message_send,KEEP_STACK ./hello_world` →
```
# stack duration[s] count
j_batch_execute/j_batch_execute_internal/j_batch_execute_same/j_kv_put_exec/j_message_send 0.000026 1
j_batch_execute/j_batch_execute_internal/j_batch_execute_same/j_db_insert_exec/j_backend_db_func_exec/j_message_send 0.000029 1
j_batch_execute/j_batch_execute_internal/j_batch_execute_same/j_kv_put_exec/j_connection_pool_pop/j_connection_pool_pop_internal/j_message_send 0.000022 1
j_batch_execute/j_batch_execute_internal/j_batch_execute_same/j_object_write_exec/j_message_send 0.000031 1
j_batch_execute/j_batch_execute_internal/j_batch_execute_same/j_db_schema_create_exec/j_backend_db_func_exec/j_message_send 0.000027 1
j_batch_execute/j_batch_execute_internal/j_batch_execute_same/j_db_schema_create_exec/j_backend_db_func_exec/j_connection_pool_pop/j_connection_pool_pop_internal/j_message_send 0.000036 1
j_batch_execute/j_batch_execute_internal/j_batch_execute_same/j_object_create_exec/j_connection_pool_pop/j_connection_pool_pop_internal/j_message_send 0.000039 1
j_batch_execute/j_batch_execute_internal/j_batch_execute_same/j_object_create_exec/j_message_send 0.000030 1   
```


 `J_TRACE=summary J_TRACE_FUNCTION=j_message_send,j_object* ./hello_world` →
```
# stack duration[s] count
j_object_create_exec/j_message_send 0.000044 2
j_message_send 0.000111 6
j_object_create_exec 0.013171 1    
```