### PR TITLE
Mark libfabric as required

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -139,7 +139,6 @@ gobject_dep = dependency('gobject-2.0',
 
 libfabric_dep = dependency('libfabric',
 	version: '>= @0@'.format(libfabric_version),
-	required: false,
 	#include_type: 'system'
 )
 


### PR DESCRIPTION
Since 85f2bea55dab0bc869b01d0eaf3c708f58e447d6 libfabric is required to build JULEA.