### PR TITLE
Explicit root group for julea-db HDF5 VOL

### DIFF
--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -380,6 +380,11 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		{
 			j_goto_error();
 		}
+		
+		// construct and store root group object to file struct
+		//CURRTODO error check
+		file_add_root_group(object, root_group_id, root_group_id_len);
+	
 	}
 	else
 	{
@@ -392,6 +397,10 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		{
 			j_goto_error();
 		}
+
+		// construct and store root group object to file struct
+		//CURRTODO error check
+		file_add_root_group(object, root_group_id, root_group_id_len);
 
 		g_assert(!j_db_iterator_next(iterator, NULL));
 
@@ -419,9 +428,7 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		}
 	}
 
-	// construct and store root group object to file struct
-	//CURRTODO error check
-	file_add_root_group(object, root_group_id, root_group_id_len);
+
 
 	return object;
 

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -175,31 +175,31 @@ _error:
 }
 
 /**
- * @brief Construct the root group for a file object.
+ * \brief Construct the root group for a file object.
  *
- * @param file A file object.
- * @param root_group_id The ID of the respective root group. This function takes the ownership of root_group_id. It should not be freed by the caller.
- * @param root_group_id_len The length of the ID.
- * @attention This function takes the ownership of root_group_id. It should not be freed by the caller.
- * @return gboolean - True for success
+ * \param file A file object.
+ * \param root_group_id The ID of the respective root group. This function takes the ownership of root_group_id. It should not be freed by the caller.
+ * \param root_group_id_len The length of the ID.
+ * \attention This function takes the ownership of root_group_id. It should not be freed by the caller.
+ * \return gboolean - TRUE for success
  */
 static gboolean
 file_add_root_group(JHDF5Object_t* file, void* root_group_id, guint64 root_group_id_len)
 {
 	JHDF5Object_t* root_group;
 
-	g_return_val_if_fail(file != NULL, false);
-	g_return_val_if_fail(file->type == J_HDF5_OBJECT_TYPE_FILE, false);
+	g_return_val_if_fail(file != NULL, FALSE);
+	g_return_val_if_fail(file->type == J_HDF5_OBJECT_TYPE_FILE, FALSE);
 
 	if (!(root_group = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_GROUP)))
 	{
-		return false;
+		return FALSE;
 	}
 
 	if (!(root_group->group.name = g_strdup("/")))
 	{
 		g_free(root_group);
-		return false;
+		return FALSE;
 	}
 
 	// do not change ref count!
@@ -211,7 +211,7 @@ file_add_root_group(JHDF5Object_t* file, void* root_group_id, guint64 root_group
 
 	file->file.root_group = root_group;
 
-	return true;
+	return TRUE;
 }
 
 void*
@@ -280,21 +280,6 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 	//create new file
 	if (!exist)
 	{
-		// this snippet seems unnecessary???
-		/*
-		H5VL_julea_db_object_unref(object);
-
-		if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_FILE)))
-		{
-			j_goto_error();
-		}
-
-		if (!(object->file.name = g_strdup(name)))
-		{
-			j_goto_error();
-		}
-		*/
-
 		if (!(entry = j_db_entry_new(julea_db_schema_file, &error)))
 		{
 			j_goto_error();

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -202,10 +202,9 @@ file_add_root_group(JHDF5Object_t* file, void* root_group_id, guint64 root_group
 		return false;
 	}
 
-	if (!(root_group->group.file = H5VL_julea_db_object_ref(file)))
-	{
-		return false;
-	}
+	// do not change ref count!
+	// otherwise the file will never be freed because the user's reference will never be the last one
+	root_group->group.file = file;
 
 	root_group->backend_id = root_group_id;
 	root_group->backend_id_len = root_group_id_len;

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -107,7 +107,6 @@ H5VL_julea_db_file_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
-
 				{
 					const gchar* index[] = {
 						"name",
@@ -177,12 +176,12 @@ _error:
 
 /**
  * @brief Construct the root group for a file object.
- * 
+ *
  * @param file A file object.
  * @param root_group_id The ID of the respective root group. This function takes the ownership of root_group_id. It should not be freed by the caller.
  * @param root_group_id_len The length of the ID.
  * @attention This function takes the ownership of root_group_id. It should not be freed by the caller.
- * @return gboolean - True for success 
+ * @return gboolean - True for success
  */
 static gboolean
 file_add_root_group(JHDF5Object_t* file, void* root_group_id, guint64 root_group_id_len)
@@ -305,7 +304,6 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 			j_goto_error();
 		}
 
-
 		if (!j_db_entry_insert(entry, batch, &error))
 		{
 			j_goto_error();
@@ -382,11 +380,10 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		{
 			j_goto_error();
 		}
-		
+
 		// construct and store root group object to file struct
 		//CURRTODO error check
 		file_add_root_group(object, root_group_id, root_group_id_len);
-	
 	}
 	else
 	{
@@ -429,8 +426,6 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 			}
 		}
 	}
-
-
 
 	return object;
 

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -280,6 +280,8 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 	//create new file
 	if (!exist)
 	{
+		// this snippet seems unnecessary???
+		/*
 		H5VL_julea_db_object_unref(object);
 
 		if (!(object = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_FILE)))
@@ -291,6 +293,7 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		{
 			j_goto_error();
 		}
+		*/
 
 		if (!(entry = j_db_entry_new(julea_db_schema_file, &error)))
 		{

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -102,6 +102,12 @@ H5VL_julea_db_file_init(hid_t vipl_id)
 					j_goto_error();
 				}
 
+				if (!j_db_schema_add_field(julea_db_schema_file, "root_group", J_DB_TYPE_ID, &error))
+				{
+					j_goto_error();
+				}
+
+
 				{
 					const gchar* index[] = {
 						"name",
@@ -169,6 +175,46 @@ _error:
 	return 1;
 }
 
+/**
+ * @brief Construct the root group for a file object.
+ * 
+ * @param file A file object.
+ * @param root_group_id The ID of the respective root group. This function takes the ownership of root_group_id. It should not be freed by the caller.
+ * @param root_group_id_len The length of the ID.
+ * @attention This function takes the ownership of root_group_id. It should not be freed by the caller.
+ * @return gboolean - True for success 
+ */
+static gboolean
+file_add_root_group(JHDF5Object_t* file, void* root_group_id, guint64 root_group_id_len)
+{
+	JHDF5Object_t* root_group;
+
+	g_return_val_if_fail(file != NULL, false);
+	g_return_val_if_fail(file->type == J_HDF5_OBJECT_TYPE_FILE, false);
+
+	if (!(root_group = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_GROUP)))
+	{
+		return false;
+	}
+
+	if (!(root_group->group.name = g_strdup("/")))
+	{
+		return false;
+	}
+
+	if (!(root_group->group.file = H5VL_julea_db_object_ref(file)))
+	{
+		return false;
+	}
+
+	root_group->backend_id = root_group_id;
+	root_group->backend_id_len = root_group_id_len;
+
+	file->file.root_group = root_group;
+
+	return true;
+}
+
 void*
 H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, hid_t dxpl_id, void** req)
 {
@@ -179,9 +225,12 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 	g_autoptr(JDBEntry) entry = NULL;
 	g_autoptr(JDBIterator) iterator = NULL;
 	g_autoptr(JDBSelector) selector = NULL;
+	g_autoptr(JDBSelector) selector_file = NULL;
+	void* root_group_id = NULL;
 	JHDF5Object_t* object = NULL;
 	JDBType type;
 	gboolean exist;
+	guint64 root_group_id_len;
 
 	(void)fcpl_id;
 	(void)fapl_id;
@@ -254,6 +303,7 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 			j_goto_error();
 		}
 
+
 		if (!j_db_entry_insert(entry, batch, &error))
 		{
 			j_goto_error();
@@ -268,10 +318,77 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		{
 			j_goto_error();
 		}
+
+		// create root group for the file
+		// do not use predefined method which would create a link
+		j_db_entry_unref(entry);
+
+		if (!(entry = j_db_entry_new(julea_db_schema_group, &error)))
+		{
+			j_goto_error();
+		}
+
+		if (!j_db_entry_set_field(entry, "file", object->backend_id, object->backend_id_len, &error))
+		{
+			j_goto_error();
+		}
+
+		if (!j_db_entry_insert(entry, batch, &error))
+		{
+			j_goto_error();
+		}
+
+		if (!j_batch_execute(batch))
+		{
+			j_goto_error();
+		}
+
+		if (!j_db_entry_get_id(entry, &root_group_id, &root_group_id_len, &error))
+		{
+			j_goto_error();
+		}
+
+		// update file record with now known root group id
+		j_db_entry_unref(entry);
+
+		if (!(entry = j_db_entry_new(julea_db_schema_file, &error)))
+		{
+			j_goto_error();
+		}
+
+		if (!j_db_entry_set_field(entry, "root_group", root_group_id, root_group_id_len, &error))
+		{
+			j_goto_error();
+		}
+
+		if (!(selector_file = j_db_selector_new(julea_db_schema_file, J_DB_SELECTOR_MODE_AND, &error)))
+		{
+			j_goto_error();
+		}
+
+		if (!j_db_selector_add_field(selector_file, "_id", J_DB_SELECTOR_OPERATOR_EQ, object->backend_id, object->backend_id_len, &error))
+		{
+			j_goto_error();
+		}
+
+		if (!j_db_entry_update(entry, selector_file, batch, &error))
+		{
+			j_goto_error();
+		}
+
+		if (!j_batch_execute(batch))
+		{
+			j_goto_error();
+		}
 	}
 	else
 	{
 		if (!j_db_iterator_get_field(iterator, "_id", &type, &object->backend_id, &object->backend_id_len, &error))
+		{
+			j_goto_error();
+		}
+
+		if (!j_db_iterator_get_field(iterator, "root_group", &type, &root_group_id, &root_group_id_len, &error))
 		{
 			j_goto_error();
 		}
@@ -302,6 +419,10 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		}
 	}
 
+	// construct and store root group object to file struct
+	//CURRTODO error check
+	file_add_root_group(object, root_group_id, root_group_id_len);
+
 	return object;
 
 _error:
@@ -320,7 +441,9 @@ H5VL_julea_db_file_open(const char* name, unsigned flags, hid_t fapl_id, hid_t d
 	g_autoptr(JBatch) batch = NULL;
 	g_autoptr(JDBIterator) iterator = NULL;
 	g_autoptr(JDBSelector) selector = NULL;
+	void* root_group_id = NULL;
 	JHDF5Object_t* object = NULL;
+	guint64 root_group_id_len;
 	JDBType type;
 
 	(void)flags;
@@ -369,6 +492,13 @@ H5VL_julea_db_file_open(const char* name, unsigned flags, hid_t fapl_id, hid_t d
 	{
 		j_goto_error();
 	}
+
+	if (!j_db_iterator_get_field(iterator, "root_group", &type, &root_group_id, &root_group_id_len, &error))
+	{
+		j_goto_error();
+	}
+
+	file_add_root_group(object, root_group_id, root_group_id_len);
 
 	g_assert(!j_db_iterator_next(iterator, NULL));
 

--- a/lib/hdf5-db/jhdf5-db-file.c
+++ b/lib/hdf5-db/jhdf5-db-file.c
@@ -198,6 +198,7 @@ file_add_root_group(JHDF5Object_t* file, void* root_group_id, guint64 root_group
 
 	if (!(root_group->group.name = g_strdup("/")))
 	{
+		g_free(root_group);
 		return false;
 	}
 
@@ -382,8 +383,10 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		}
 
 		// construct and store root group object to file struct
-		//CURRTODO error check
-		file_add_root_group(object, root_group_id, root_group_id_len);
+		if (!file_add_root_group(object, root_group_id, root_group_id_len))
+		{
+			j_goto_error();
+		}
 	}
 	else
 	{
@@ -398,8 +401,10 @@ H5VL_julea_db_file_create(const char* name, unsigned flags, hid_t fcpl_id, hid_t
 		}
 
 		// construct and store root group object to file struct
-		//CURRTODO error check
-		file_add_root_group(object, root_group_id, root_group_id_len);
+		if (!file_add_root_group(object, root_group_id, root_group_id_len))
+		{
+			j_goto_error();
+		}
 
 		g_assert(!j_db_iterator_next(iterator, NULL));
 
@@ -502,7 +507,10 @@ H5VL_julea_db_file_open(const char* name, unsigned flags, hid_t fapl_id, hid_t d
 		j_goto_error();
 	}
 
-	file_add_root_group(object, root_group_id, root_group_id_len);
+	if (!file_add_root_group(object, root_group_id, root_group_id_len))
+	{
+		j_goto_error();
+	}
 
 	g_assert(!j_db_iterator_next(iterator, NULL));
 

--- a/lib/hdf5-db/jhdf5-db-group.c
+++ b/lib/hdf5-db/jhdf5-db-group.c
@@ -221,22 +221,6 @@ _error:
 	return 1;
 }
 
-/// \todo remove this (by adding an explicit root group)
-JHDF5Object_t*
-H5VL_julea_db_group_root_fake_helper(JHDF5Object_t* file)
-{
-	JHDF5Object_t* fake_root = NULL;
-
-	if (file->type == J_HDF5_OBJECT_TYPE_FILE)
-	{
-		fake_root = H5VL_julea_db_object_new(J_HDF5_OBJECT_TYPE_GROUP);
-		fake_root->group.file = H5VL_julea_db_object_ref(file);
-		fake_root->group.name = g_strdup("/");
-	}
-
-	return fake_root;
-}
-
 void*
 H5VL_julea_db_group_create(void* obj, const H5VL_loc_params_t* loc_params, const char* name, hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id, hid_t dxpl_id, void** req)
 {
@@ -379,6 +363,7 @@ H5VL_julea_db_group_open(void* obj, const H5VL_loc_params_t* loc_params, const c
 			g_assert_not_reached();
 			j_goto_error();
 	}
+
 
 	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
 	{

--- a/lib/hdf5-db/jhdf5-db-group.c
+++ b/lib/hdf5-db/jhdf5-db-group.c
@@ -370,7 +370,6 @@ H5VL_julea_db_group_open(void* obj, const H5VL_loc_params_t* loc_params, const c
 			j_goto_error();
 	}
 
-
 	if (!(batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT)))
 	{
 		j_goto_error();

--- a/lib/hdf5-db/jhdf5-db-group.c
+++ b/lib/hdf5-db/jhdf5-db-group.c
@@ -195,6 +195,12 @@ H5VL_julea_db_group_truncate_file(void* obj)
 		j_goto_error();
 	}
 
+	// do not delete the file's root group
+	if (!j_db_selector_add_field(selector, "_id", J_DB_SELECTOR_OPERATOR_NE, file->file.root_group->backend_id, file->file.root_group->backend_id_len, &error))
+	{
+		j_goto_error();
+	}
+
 	if (!(entry = j_db_entry_new(julea_db_schema_group, &error)))
 	{
 		j_goto_error();
@@ -345,8 +351,8 @@ H5VL_julea_db_group_open(void* obj, const H5VL_loc_params_t* loc_params, const c
 	switch (parent->type)
 	{
 		case J_HDF5_OBJECT_TYPE_FILE:
-			file = parent;
-			break;
+			// only the root group has the file as parent
+			return H5VL_julea_db_object_ref(parent->file.root_group);
 		case J_HDF5_OBJECT_TYPE_DATASET:
 			file = parent->dataset.file;
 			break;

--- a/lib/hdf5-db/jhdf5-db-group.c
+++ b/lib/hdf5-db/jhdf5-db-group.c
@@ -351,7 +351,11 @@ H5VL_julea_db_group_open(void* obj, const H5VL_loc_params_t* loc_params, const c
 	switch (parent->type)
 	{
 		case J_HDF5_OBJECT_TYPE_FILE:
-			// only the root group has the file as parent
+			/*
+			Only the root group has the file as parent.
+			This is enforced in H5VL_julea_db_link_get_helper and H5VL_julea_db_link_create_helper
+			by transparent use of the file's root group instead of the file itself.
+			*/
 			return H5VL_julea_db_object_ref(parent->file.root_group);
 		case J_HDF5_OBJECT_TYPE_DATASET:
 			file = parent->dataset.file;

--- a/lib/hdf5-db/jhdf5-db-link.c
+++ b/lib/hdf5-db/jhdf5-db-link.c
@@ -276,6 +276,12 @@ H5VL_julea_db_link_get_helper(JHDF5Object_t* parent, JHDF5Object_t* child, const
 	g_return_val_if_fail(parent != NULL, FALSE);
 	g_return_val_if_fail(child != NULL, FALSE);
 
+	// special case: file -> root group
+	if (parent->type == J_HDF5_OBJECT_TYPE_FILE)
+	{
+		parent = parent->file.root_group;
+	}
+
 	if (!(selector = j_db_selector_new(julea_db_schema_link, J_DB_SELECTOR_MODE_AND, &error)))
 	{
 		j_goto_error();
@@ -349,6 +355,8 @@ H5VL_julea_db_link_create_helper(JHDF5Object_t* parent, JHDF5Object_t* child, co
 	{
 		case J_HDF5_OBJECT_TYPE_FILE:
 			file = parent;
+			// use root group as parent
+			parent = parent->file.root_group;
 			break;
 		case J_HDF5_OBJECT_TYPE_DATASET:
 			file = parent->dataset.file;
@@ -604,7 +612,7 @@ H5VL_julea_db_link_iterate_helper(JHDF5Object_t* object, hbool_t recursive, gboo
 	{
 		/// \todo root group needs to be faked here (maybe add it as real group?)
 		curr_parent_type = H5I_GROUP;
-		curr_parent_obj = H5VL_julea_db_group_root_fake_helper(object);
+		curr_parent_obj = H5VL_julea_db_object_ref(object->file.root_group);
 	}
 	else
 	{

--- a/lib/hdf5-db/jhdf5-db-link.c
+++ b/lib/hdf5-db/jhdf5-db-link.c
@@ -633,12 +633,12 @@ H5VL_julea_db_link_iterate_helper(JHDF5Object_t* object, hbool_t recursive, gboo
 		j_goto_error();
 	}
 
-	if (!j_db_selector_add_field(link_selector, "parent", J_DB_SELECTOR_OPERATOR_EQ, object->backend_id, object->backend_id_len, NULL))
+	if (!j_db_selector_add_field(link_selector, "parent", J_DB_SELECTOR_OPERATOR_EQ, curr_parent_obj->backend_id, curr_parent_obj->backend_id_len, NULL))
 	{
 		j_goto_error();
 	}
 
-	if (!j_db_selector_add_field(link_selector, "parent_type", J_DB_SELECTOR_OPERATOR_EQ, &object->type, sizeof(JHDF5ObjectType), NULL))
+	if (!j_db_selector_add_field(link_selector, "parent_type", J_DB_SELECTOR_OPERATOR_EQ, &(curr_parent_obj->type), sizeof(JHDF5ObjectType), NULL))
 	{
 		j_goto_error();
 	}

--- a/lib/hdf5-db/jhdf5-db-link.c
+++ b/lib/hdf5-db/jhdf5-db-link.c
@@ -610,7 +610,6 @@ H5VL_julea_db_link_iterate_helper(JHDF5Object_t* object, hbool_t recursive, gboo
 
 	if (object->type == J_HDF5_OBJECT_TYPE_FILE)
 	{
-		/// \todo root group needs to be faked here (maybe add it as real group?)
 		curr_parent_type = H5I_GROUP;
 		curr_parent_obj = H5VL_julea_db_object_ref(object->file.root_group);
 	}

--- a/lib/hdf5-db/jhdf5-db-shared.c
+++ b/lib/hdf5-db/jhdf5-db-shared.c
@@ -120,7 +120,15 @@ H5VL_julea_db_object_unref(JHDF5Object_t* object)
 		{
 			case J_HDF5_OBJECT_TYPE_FILE:
 				g_free(object->file.name);
-				H5VL_julea_db_object_unref(object->file.root_group);
+
+				// root group ressources can be directly freed here
+				if (object->file.root_group)
+				{
+					g_free(object->file.root_group->group.name);
+					g_free(object->file.root_group->backend_id);
+					g_free(object->file.root_group);
+				}
+
 				break;
 			case J_HDF5_OBJECT_TYPE_DATASET:
 				H5VL_julea_db_object_unref(object->dataset.file);

--- a/lib/hdf5-db/jhdf5-db-shared.c
+++ b/lib/hdf5-db/jhdf5-db-shared.c
@@ -120,6 +120,7 @@ H5VL_julea_db_object_unref(JHDF5Object_t* object)
 		{
 			case J_HDF5_OBJECT_TYPE_FILE:
 				g_free(object->file.name);
+				H5VL_julea_db_object_unref(object->file.root_group);
 				break;
 			case J_HDF5_OBJECT_TYPE_DATASET:
 				H5VL_julea_db_object_unref(object->dataset.file);

--- a/lib/hdf5-db/jhdf5-db.h
+++ b/lib/hdf5-db/jhdf5-db.h
@@ -55,6 +55,7 @@ struct JHDF5Object_t
 		struct
 		{
 			char* name;
+			JHDF5Object_t* root_group;
 		} file;
 		struct
 		{
@@ -217,11 +218,10 @@ herr_t H5VL_julea_db_link_get_info_helper(JHDF5Object_t* obj, const H5VL_loc_par
 herr_t H5VL_julea_db_link_iterate_helper(JHDF5Object_t* object, hbool_t recursive, gboolean attr, H5_index_t idx_type, H5_iter_order_t order, hsize_t* idx_p, JHDF5Iterate_Func_t op, void* op_data);
 herr_t H5VL_julea_db_link_exists_helper(JHDF5Object_t* object, const gchar* name, htri_t* exists);
 
-// group helper
-JHDF5Object_t* H5VL_julea_db_group_root_fake_helper(JHDF5Object_t* file);
-
 // shared structs
 extern JDBSchema* julea_db_schema_link;
+extern JDBSchema* julea_db_schema_group;
+
 
 #define j_goto_error() \
 	do \

--- a/lib/hdf5-db/jhdf5-db.h
+++ b/lib/hdf5-db/jhdf5-db.h
@@ -222,7 +222,6 @@ herr_t H5VL_julea_db_link_exists_helper(JHDF5Object_t* object, const gchar* name
 extern JDBSchema* julea_db_schema_link;
 extern JDBSchema* julea_db_schema_group;
 
-
 #define j_goto_error() \
 	do \
 	{ \


### PR DESCRIPTION
The root group is explicitly stored in the database.
The advantage is that no group needs to be faked for iteration.
Instead of using the link table the root group's ID is stored in the file table as it is a 1:1 relationship.

Giving an `hid_t` file identifier as location will transparently use the root group instead.
Consequently the only parent types in the link table are now groups or datasets.