### PR TITLE
Enhance expected test fails

### DIFF
--- a/test/hdf5/hdf-attribute.c
+++ b/test/hdf5/hdf-attribute.c
@@ -113,7 +113,8 @@ test_hdf_attribute_group(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -150,7 +151,8 @@ test_hdf_attribute_set(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -191,7 +193,8 @@ test_hdf_attribute_type(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -269,7 +272,7 @@ test_hdf_attribute_iterate(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_kv_fail();
 }
 
 #endif

--- a/test/hdf5/hdf-dataset.c
+++ b/test/hdf5/hdf-dataset.c
@@ -110,7 +110,8 @@ test_hdf_dataset_create_delete_open_close(hid_t* file_fixture, gconstpointer uda
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -170,7 +171,8 @@ test_hdf_dataset_extend(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -214,7 +216,8 @@ test_hdf_dataset_invalid_extend(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -340,7 +343,8 @@ test_hdf_dataset_write_read_selection(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -466,7 +470,8 @@ test_hdf_dataset_write_read_single(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 #endif

--- a/test/hdf5/hdf-datatype.c
+++ b/test/hdf5/hdf-datatype.c
@@ -120,7 +120,8 @@ test_hdf_datatype_create_compound(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("datatype commit is not yet implemented!");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -155,7 +156,8 @@ test_hdf_datatype_create_array(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("datatype commit is not yet implemented!");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 #endif

--- a/test/hdf5/hdf-file.c
+++ b/test/hdf5/hdf-file.c
@@ -62,7 +62,8 @@ test_hdf_file_create_delete(void)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("delete not implemented yet");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -84,7 +85,8 @@ test_hdf_file_double_create(void)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("delete not implemented yet");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -112,7 +114,8 @@ test_hdf_file_open_close(void)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("delete not implemented yet");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -127,10 +130,7 @@ test_hdf_file_open_non_existent(void)
 
 	J_TEST_TRAP_END;
 
-	if (g_str_equal(g_getenv("HDF5_VOL_CONNECTOR"), "julea-kv"))
-	{
-		g_test_incomplete("Fails currently for julea-kv");
-	}
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -155,7 +155,8 @@ test_hdf_file_delete(void)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("delete not implemented yet");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -170,7 +171,8 @@ test_hdf_file_delete_non_existent(void)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("delete not implemented yet");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 #endif

--- a/test/hdf5/hdf-group-link.c
+++ b/test/hdf5/hdf-group-link.c
@@ -70,7 +70,8 @@ test_hdf_group_create_delete_open_close(hid_t* file_fixture, gconstpointer udata
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -104,7 +105,8 @@ test_hdf_link_nested_group(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -143,7 +145,8 @@ test_hdf_link_hard_delete(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -179,7 +182,8 @@ test_hdf_link_soft(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -200,7 +204,8 @@ test_hdf_link_invalid(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Fails currently");
+	j_expect_vol_db_fail();
+	j_expect_vol_kv_fail();
 }
 
 static herr_t
@@ -260,8 +265,7 @@ test_hdf_link_iterate(hid_t* file_fixture, gconstpointer udata)
 	H5Sclose(space);
 
 	J_TEST_TRAP_END;
-
-	g_test_incomplete("Fails currently");
+	j_expect_vol_kv_fail();
 }
 
 #endif

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -24,6 +24,30 @@
 
 #ifdef HAVE_HDF5
 
+void 
+j_expect_vol_db_fail(void)
+{
+    const gchar* conn_name = NULL;
+    conn_name = g_getenv("HDF5_VOL_CONNECTOR");
+
+    if(!g_strcmp0(conn_name, "julea-db"))
+    {
+	    g_test_incomplete("This test is currently expected to fail for the DB VOL plugin.");
+    }
+}
+
+void 
+j_expect_vol_kv_fail(void)
+{
+    const gchar* conn_name = NULL;
+    conn_name = g_getenv("HDF5_VOL_CONNECTOR");
+
+    if(!g_strcmp0(conn_name, "julea-kv"))
+    {
+	    g_test_incomplete("This test is currently expected to fail for the KV VOL plugin.");
+    }
+}
+
 void
 j_test_hdf_file_fixture_setup(hid_t* file, gconstpointer udata)
 {

--- a/test/hdf5/hdf-helper.c
+++ b/test/hdf5/hdf-helper.c
@@ -21,31 +21,32 @@
  **/
 
 #include "hdf-helper.h"
+#include "../test.h"
 
 #ifdef HAVE_HDF5
 
-void 
+void
 j_expect_vol_db_fail(void)
 {
-    const gchar* conn_name = NULL;
-    conn_name = g_getenv("HDF5_VOL_CONNECTOR");
+	const gchar* conn_name = NULL;
+	conn_name = g_getenv("HDF5_VOL_CONNECTOR");
 
-    if(!g_strcmp0(conn_name, "julea-db"))
-    {
-	    g_test_incomplete("This test is currently expected to fail for the DB VOL plugin.");
-    }
+	if (!g_strcmp0(conn_name, "julea-db"))
+	{
+		j_expect_fail("This test is currently expected to fail for the DB VOL plugin.");
+	}
 }
 
-void 
+void
 j_expect_vol_kv_fail(void)
 {
-    const gchar* conn_name = NULL;
-    conn_name = g_getenv("HDF5_VOL_CONNECTOR");
+	const gchar* conn_name = NULL;
+	conn_name = g_getenv("HDF5_VOL_CONNECTOR");
 
-    if(!g_strcmp0(conn_name, "julea-kv"))
-    {
-	    g_test_incomplete("This test is currently expected to fail for the KV VOL plugin.");
-    }
+	if (!g_strcmp0(conn_name, "julea-kv"))
+	{
+		j_expect_fail("This test is currently expected to fail for the KV VOL plugin.");
+	}
 }
 
 void

--- a/test/hdf5/hdf-helper.h
+++ b/test/hdf5/hdf-helper.h
@@ -34,6 +34,9 @@
 
 #include <hdf5.h>
 
+void j_expect_vol_db_fail(void);
+void j_expect_vol_kv_fail(void);
+
 /**
  * Create a simple HDF5 file to test groups, datasets, ...
  *

--- a/test/hdf5/hdf-object.c
+++ b/test/hdf5/hdf-object.c
@@ -84,7 +84,7 @@ test_hdf_object_open_close(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("object open for kv not implemented!");
+	j_expect_vol_kv_fail();
 }
 
 static void
@@ -114,7 +114,7 @@ test_hdf_object_open_invalid(hid_t* file_fixture, gconstpointer udata)
 
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("object open for kv not implemented!");
+	j_expect_vol_kv_fail();
 }
 
 #endif

--- a/test/kv/kv.c
+++ b/test/kv/kv.c
@@ -102,7 +102,7 @@ test_kv_put_delete(void)
 	g_assert_false(ret);
 	J_TEST_TRAP_END;
 
-	g_test_incomplete("Known issue. See #116");
+	j_expect_fail("Known issue. See #116");
 }
 
 static void

--- a/test/test.h
+++ b/test/test.h
@@ -30,6 +30,10 @@
 		g_test_trap_assert_passed(); \
 	}
 
+#define j_expect_fail(msg) \
+	if (!g_getenv("J_TEST_IGNORE_EXPECTED_FAIL")) \
+		g_test_incomplete(msg);
+
 void test_core_background_operation(void);
 void test_core_batch(void);
 void test_core_cache(void);


### PR DESCRIPTION
This PR enables to distinguish between test cases that fail only for the HDF5 KV plugin and not for the DB plugin and vice versa.
So the features that are expected to work for the plugins are documented in the code itself.

Additionally a new macro for all JULEA tests is introduced which enables to completely ignore expected failures by setting `J_TEST_IGNORE_EXPECTED_FAIL` to any value.
This is handy to check if some tests are passing after code changes and thus simplifies development workflow.