### PR TITLE
Suppress Benchmark Warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -574,6 +574,7 @@ julea_benchmark_srcs = files([
 
 executable('julea-benchmark', julea_benchmark_srcs,
 	dependencies: common_deps + [julea_dep, julea_client_deps['object'], julea_client_deps['kv'], julea_client_deps['db'], julea_client_deps['item']] + hdf_deps,
+	c_args: ['-Wno-stack-protector'],
 	include_directories: [julea_incs] + [include_directories('benchmark')],
 )
 


### PR DESCRIPTION
Suppress the compiler warnings for the benchmark tool.

```
../benchmark/object/object.c: In function ‘_benchmark_object_write’:
../benchmark/object/object.c:307:1: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
  307 | _benchmark_object_write(BenchmarkRun* run, gboolean use_batch, guint block_size)
      | ^~~~~~~~~~~~~~~~~~~~~~~
../benchmark/object/object.c: In function ‘_benchmark_object_read’:
../benchmark/object/object.c:232:1: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
  232 | _benchmark_object_read(BenchmarkRun* run, gboolean use_batch, guint block_size)
      | ^~~~~~~~~~~~~~~~~~~~~~
[102/178] Compiling C object julea-benchmark.p/benchmark_object_distributed-object.c.o
../benchmark/object/distributed-object.c: In function ‘_benchmark_distributed_object_write’:
../benchmark/object/distributed-object.c:315:1: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
  315 | _benchmark_distributed_object_write(BenchmarkRun* run, gboolean use_batch, guint block_size)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../benchmark/object/distributed-object.c: In function ‘_benchmark_distributed_object_read’:
../benchmark/object/distributed-object.c:238:1: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
  238 | _benchmark_distributed_object_read(BenchmarkRun* run, gboolean use_batch, guint block_size)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[107/178] Compiling C object julea-benchmark.p/benchmark_item_item.c.o
../benchmark/item/item.c: In function ‘_benchmark_item_write’:
../benchmark/item/item.c:380:1: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
  380 | _benchmark_item_write(BenchmarkRun* run, gboolean use_batch, guint block_size)
      | ^~~~~~~~~~~~~~~~~~~~~
../benchmark/item/item.c: In function ‘_benchmark_item_read’:
../benchmark/item/item.c:303:1: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
  303 | _benchmark_item_read(BenchmarkRun* run, gboolean use_batch, guint block_size)
      | ^~~~~~~~~~~~~~~~~~~~
[110/178] Compiling C object julea-benchmark.p/benchmark_hdf5_hdf.c.o
../benchmark/hdf5/hdf.c: In function ‘create_dataset’:
../benchmark/hdf5/hdf.c:168:1: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
  168 | create_dataset(hid_t file, gchar const* name, guint dimensions, hid_t* dataspace_out)
      | ^~~~~~~~~~~~~~
[178/178] Linking target julea-test
```