### PR TITLE
adding benchmark executable for installing.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -575,6 +575,7 @@ julea_benchmark_srcs = files([
 executable('julea-benchmark', julea_benchmark_srcs,
 	dependencies: common_deps + [julea_dep, julea_client_deps['object'], julea_client_deps['kv'], julea_client_deps['db'], julea_client_deps['item']] + hdf_deps,
 	include_directories: [julea_incs] + [include_directories('benchmark')],
+	install: true,
 )
 
 julea_server_srcs = files([


### PR DESCRIPTION
I found no way to run the benchmark using the release-build. 
Adding the executable on installation fixed this.

For the release build, the backends cannot be found/are not checked the same way as with the debug build.
So installation is required to find any backend (which in turn requires the prefix).
However, the benchmark executable is not built then which means the benchmark script does not work.
