### PR TITLE
Fix DB benchmark for MySQL/MariaDB

### DIFF
--- a/benchmark/db/common.c
+++ b/benchmark/db/common.c
@@ -115,10 +115,10 @@ _benchmark_db_prepare_scheme(gchar const* namespace, gboolean use_batch, gboolea
 		g_assert_true(ret);
 	}
 
-	ret = j_db_schema_create(b_scheme, batch, &b_s_error);
+	ret = j_db_schema_create(b_scheme, batch, NULL);
 	g_assert_null(b_s_error);
 	g_assert_true(ret);
-	ret = j_db_schema_delete(b_scheme, delete_batch, &b_s_error);
+	ret = j_db_schema_delete(b_scheme, delete_batch, NULL);
 	g_assert_null(b_s_error);
 	g_assert_true(ret);
 


### PR DESCRIPTION
In db/common.c `schema_create` and `schema_delete`are called, passing an error, while in db/schema.c there are notes that the user should not pass an error to these functions.

Currently, it seems to work (maybe out of luck) when running SQLite server on the same host as the benchmark.
However, when MariaDB is used (with Singularity), it fails.

```
/db/entry/insert:                     **
JULEA:ERROR:../benchmark/db/common.c:131:_benchmark_db_prepare_scheme: 'ret' should be TRUE
Bail out! JULEA:ERROR:../benchmark/db/common.c:131:_benchmark_db_prepare_scheme: 'ret' should be TRUE
```

I assume this may be because the MariaDB server tries to access the address passed in the error pointer in its own address space. After all, the MariaDB server should not be able to access anything outside the container, right?

Passing NULL instead of the error pointer, seems to fix the problem.