### PR TITLE
added Python support for JULEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ bld*/
 
 # Visual Studio Code
 .vscode/
+
+# Python
+**/__pycache__/
+
+# C/C++ LSP
+.ccls-cache/

--- a/benchmark/python/benchmark.py
+++ b/benchmark/python/benchmark.py
@@ -1,0 +1,32 @@
+from kv.kv import benchmark_kv
+from object.object import benchmark_object
+from object.distributed_object import benchmark_distributed_object
+from db.entry import benchmark_db_entry
+from db.iterator import benchmark_db_iterator
+from db.schema import benchmark_db_schema
+from item.collection import benchmark_collection
+from item.item import benchmark_item
+from benchmarkrun import print_header
+from sys import argv
+
+if __name__ == "__main__":
+    runs = []
+    iterations = 1000
+    machine_readable = ("-m" in argv)
+    print_header(machine_readable)
+
+    # KV Client
+    benchmark_kv(runs, iterations, machine_readable)
+
+    # Object Client
+    benchmark_distributed_object(runs, iterations, machine_readable)
+    benchmark_object(runs, iterations, machine_readable)
+
+    # DB Client
+    benchmark_db_entry(runs, iterations, machine_readable)
+    benchmark_db_iterator(runs, iterations, machine_readable)
+    benchmark_db_schema(runs, iterations, machine_readable)
+
+    # Item Client
+    benchmark_collection(runs, iterations, machine_readable)
+    benchmark_item(runs, iterations, machine_readable)

--- a/benchmark/python/benchmarkrun.py
+++ b/benchmark/python/benchmarkrun.py
@@ -1,0 +1,75 @@
+from time import perf_counter_ns
+
+class BenchmarkRun:
+    def __init__(self, name, iterations, machine_readable):
+        self.name = name
+        self.iterations = iterations
+        self.timer_started = False
+        self.start = None
+        self.stop = None
+        self.operations = iterations
+        self.machine_readable = machine_readable
+
+    def start_timer(self):
+        self.timer_started = True
+        self.start = perf_counter_ns()
+
+    def stop_timer(self):
+        self.timer_started = False
+        self.stop = perf_counter_ns()
+
+    def get_runtime_ms(self):
+        val = self.get_runtime_ns()
+        return val / 1000000 if val != None else None
+
+    def get_runtime_s(self):
+        val = self.get_runtime_ns()
+        return val / 1000000000 if val != None else None
+
+    def get_runtime_ns(self):
+        if self.timer_started or self.stop == None:
+            return None
+        else:
+            return self.stop - self.start
+
+    def print_result(self):
+        if self.machine_readable:
+            print(f"{self.name},{self.get_runtime_s()},{self.operations}")
+        else:
+            name_col = self.name.ljust(60," ")
+            runtime_col = f"{self.get_runtime_s():.3f}".rjust(8," ") + " seconds"
+            operations_col = f"{int(self.operations/self.get_runtime_s())}/s".rjust(12," ")
+            print(f"{name_col} | {runtime_col} | {operations_col}")
+
+    def print_empty(self):
+        if self.machine_readable:
+            print(f"{self.name},-,-")
+        else:
+            name_col = self.name.ljust(60," ")
+            runtime_col = "-".rjust(8," ") + " seconds"
+            operations_col = "-/s".rjust(12," ")
+            print(f"{name_col} | {runtime_col} | {operations_col}")
+
+def append_to_benchmark_list_and_run(_list, run, func):
+    _list.append(run)
+    try:
+        func(run)
+        run.print_result()
+    except:
+        run.print_empty()
+
+def print_result_table_header():
+    name_col = "Name".ljust(60," ")
+    runtime_col = "Duration".ljust(16," ")
+    operations_col = f"Operations/s".rjust(12," ")
+    header = f"{name_col} | {runtime_col} | {operations_col}"
+    print(header+"\n"+len(header)*"-")
+
+def print_machine_readable_header():
+    print("name,elapsed,operations")
+
+def print_header(machine_readable):
+    if machine_readable:
+        print_machine_readable_header()
+    else:
+        print_result_table_header()

--- a/benchmark/python/db/common.py
+++ b/benchmark/python/db/common.py
@@ -1,0 +1,136 @@
+from julea import lib, encode, ffi
+
+N = 1 << 12
+N_GET_DIVIDER = N >> 8
+N_PRIME = 11971
+N_MODULUS = 256
+CLASS_MODULUS = N >> 3
+CLASS_LIMIT = CLASS_MODULUS >> 1
+SIGNED_FACTOR = N_PRIME
+USIGNED_FACTOR = N_PRIME
+FLOAT_FACTOR = 3.1415926
+
+def _benchmark_db_prepare_scheme(namespace_encoded, use_batch, use_index_all,
+                                 use_index_single, batch, delete_batch):
+    b_s_error_ptr = ffi.new("GError*")
+    b_s_error_ptr = ffi.NULL
+    table_name = encode("table")
+    string_name = encode("string")
+    float_name = encode("float")
+    uint_name = encode("uint")
+    sint_name = encode("sint")
+    blob_name = encode("blob")
+    b_scheme = lib.j_db_schema_new(namespace_encoded, table_name, b_s_error_ptr)
+    assert b_scheme != ffi.NULL
+    assert b_s_error_ptr == ffi.NULL
+    assert lib.j_db_schema_add_field(b_scheme, string_name,
+                                     lib.J_DB_TYPE_STRING, b_s_error_ptr)
+    assert b_s_error_ptr == ffi.NULL
+    assert lib.j_db_schema_add_field(b_scheme, float_name,
+                                     lib.J_DB_TYPE_FLOAT64, b_s_error_ptr)
+    assert b_s_error_ptr == ffi.NULL
+    assert lib.j_db_schema_add_field(b_scheme, uint_name, lib.J_DB_TYPE_UINT64,
+                                     b_s_error_ptr)
+    assert b_s_error_ptr == ffi.NULL
+    assert lib.j_db_schema_add_field(b_scheme, sint_name, lib.J_DB_TYPE_UINT64,
+                                     b_s_error_ptr)
+    assert b_s_error_ptr == ffi.NULL
+    assert lib.j_db_schema_add_field(b_scheme, blob_name, lib.J_DB_TYPE_BLOB,
+                                     b_s_error_ptr)
+    assert b_s_error_ptr == ffi.NULL
+    if use_index_all:
+        names = ffi.new("char*[5]")
+        names[0] = encode("string")
+        names[1] = encode("float")
+        names[2] = encode("uint")
+        names[3] = encode("sint")
+        names[4] = ffi.NULL
+        assert lib.j_db_schema_add_index(b_scheme, names, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+    if use_index_single:
+        names = ffi.new("char*[2]")
+        names[1] = ffi.NULL
+        names[0] = encode("string")
+        assert lib.j_db_schema_add_index(b_scheme, names, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        names[0] = encode("float")
+        assert lib.j_db_schema_add_index(b_scheme, names, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        names[0] = encode("uint")
+        assert lib.j_db_schema_add_index(b_scheme, names, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        names[0] = encode("sint")
+        assert lib.j_db_schema_add_index(b_scheme, names, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+    assert lib.j_db_schema_create(b_scheme, batch, b_s_error_ptr)
+    assert b_s_error_ptr == ffi.NULL
+    assert lib.j_db_schema_delete(b_scheme, delete_batch, b_s_error_ptr)
+    assert b_s_error_ptr == ffi.NULL
+    if not use_batch:
+        assert lib.j_batch_execute(batch)
+    return lib.j_db_schema_ref(b_scheme)
+
+def _benchmark_db_get_identifier(i):
+    return f"{i * SIGNED_FACTOR % N_MODULUS:x}-benchmark-{i}"
+
+def _benchmark_db_insert(run, scheme, namespace, use_batch, use_index_all,
+                         use_index_single, use_timer):
+    b_scheme = None
+    b_s_error_ptr = ffi.new("GError*")
+    b_s_error_ptr = ffi.NULL
+    namespace_encoded = encode(namespace)
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    if use_timer:
+        assert scheme == None
+        assert run != None
+        b_scheme = _benchmark_db_prepare_scheme(namespace_encoded, use_batch,
+                                                use_index_all, use_index_single,
+                                                batch, delete_batch)
+        assert b_scheme != None
+        run.start_timer()
+    else:
+        assert use_batch
+        assert run == None
+        lib.j_db_schema_ref(scheme)
+        b_scheme = scheme
+    for i in range(N):
+        i_signed_ptr = ffi.new("long*")
+        i_signed_ptr[0] = ((i * SIGNED_FACTOR) % CLASS_MODULUS) - CLASS_LIMIT
+        i_usigned_ptr = ffi.new("unsigned long*")
+        i_usigned_ptr[0] = ((i * USIGNED_FACTOR) % CLASS_MODULUS)
+        i_float_ptr = ffi.new("double*")
+        i_float_ptr[0] = i_signed_ptr[0] * FLOAT_FACTOR
+        string = encode(_benchmark_db_get_identifier(i))
+        string_name = encode("string")
+        float_name = encode("float")
+        sint_name = encode("sint")
+        uint_name = encode("uint")
+        entry = lib.j_db_entry_new(b_scheme, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_entry_set_field(entry, string_name, string, 0,
+                                        b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_entry_set_field(entry, float_name, i_float_ptr, 0,
+                                        b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_entry_set_field(entry, sint_name, i_signed_ptr, 0,
+                                        b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_entry_set_field(entry, uint_name, i_usigned_ptr, 0,
+                                        b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_entry_insert(entry, batch, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+    if use_batch or not use_timer:
+        lib.j_batch_execute(batch)
+    if use_timer:
+        run.stop_timer()
+        assert lib.j_batch_execute(delete_batch)
+        run.operations = N
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+    lib.j_db_entry_unref(entry)
+    lib.j_db_schema_unref(b_scheme)

--- a/benchmark/python/db/entry.py
+++ b/benchmark/python/db/entry.py
@@ -1,0 +1,204 @@
+from benchmarkrun import BenchmarkRun, append_to_benchmark_list_and_run
+from julea import lib, encode, ffi
+from db.common import _benchmark_db_insert, _benchmark_db_prepare_scheme, _benchmark_db_get_identifier, N, N_GET_DIVIDER, N_PRIME, SIGNED_FACTOR, CLASS_MODULUS, CLASS_LIMIT
+
+def benchmark_db_entry(benchmarkrun_list, iterations, machine_readable):
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/insert", iterations, machine_readable), benchmark_db_insert)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/insert-batch", iterations, machine_readable), benchmark_db_insert_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/insert-index-single", iterations, machine_readable), benchmark_db_insert_index_single)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/insert-batch-index-single", iterations, machine_readable), benchmark_db_insert_batch_index_single)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/insert-index-all", iterations, machine_readable), benchmark_db_insert_index_all)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/insert-batch-index-all", iterations, machine_readable), benchmark_db_insert_batch_index_all)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/insert-index-mixed", iterations, machine_readable), benchmark_db_insert_index_mixed)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/insert-batch-index-mixed", iterations, machine_readable), benchmark_db_insert_batch_index_mixed)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/delete", iterations, machine_readable), benchmark_db_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/delete-batch", iterations, machine_readable), benchmark_db_delete_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/delete-index-single", iterations, machine_readable), benchmark_db_delete_index_single)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/delete-batch-index-single", iterations, machine_readable), benchmark_db_delete_batch_index_single)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/delete-index-all", iterations, machine_readable), benchmark_db_delete_index_all)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/delete-batch-index-all", iterations, machine_readable), benchmark_db_delete_batch_index_all)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/delete-index-mixed", iterations, machine_readable), benchmark_db_delete_index_mixed)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/delete-batch-index-mixed", iterations, machine_readable), benchmark_db_delete_batch_index_mixed)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/update", iterations, machine_readable), benchmark_db_update)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/update-batch", iterations, machine_readable), benchmark_db_update_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/update-index-single", iterations, machine_readable), benchmark_db_update_index_single)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/update-batch-index-single", iterations, machine_readable), benchmark_db_update_batch_index_single)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/update-index-all", iterations, machine_readable), benchmark_db_update_index_all)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/update-batch-index-all", iterations, machine_readable), benchmark_db_update_batch_index_all)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/update-index-mixed", iterations, machine_readable), benchmark_db_update_index_mixed)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/entry/update-batch-index-mixed", iterations, machine_readable), benchmark_db_update_batch_index_mixed)
+
+def benchmark_db_insert(run):
+    _benchmark_db_insert(run, None, "benchmark_insert", False, False, False,
+                         True)
+
+def benchmark_db_insert_batch(run):
+    _benchmark_db_insert(run, None, "benchmark_insert_batch", True, False,
+                         False, True)
+
+def benchmark_db_insert_index_single(run):
+    _benchmark_db_insert(run, None, "benchmark_insert_index_single", False,
+                         False, True, True)
+
+def benchmark_db_insert_batch_index_single(run):
+    _benchmark_db_insert(run, None, "benchmark_insert_batch_index_single", True,
+                         False, True, True)
+
+def benchmark_db_insert_index_all(run):
+    _benchmark_db_insert(run, None, "benchmark_insert_index_all", False, True,
+                         False, True)
+
+def benchmark_db_insert_batch_index_all(run):
+    _benchmark_db_insert(run, None, "benchmark_insert_batch_index_all", True,
+                         True, False, True)
+
+def benchmark_db_insert_index_mixed(run):
+    _benchmark_db_insert(run, None, "benchmakr_insert_index_mixed", False, True,
+                         True, True)
+
+def benchmark_db_insert_batch_index_mixed(run):
+    _benchmark_db_insert(run, None, "benchmakr_insert_batch_index_mixed", True,
+                         True, True, True)
+
+def benchmark_db_delete(run):
+    _benchmark_db_delete(run, "benchmark_delete", False, False, False)
+
+def benchmark_db_delete_batch(run):
+    _benchmark_db_delete(run, "benchmark_delete_batch", True, False, False)
+
+def benchmark_db_delete_index_single(run):
+    _benchmark_db_delete(run, "benchmark_delete_index_single", False, False,
+                         True)
+
+def benchmark_db_delete_batch_index_single(run):
+    _benchmark_db_delete(run, "benchmark_delete_batch_index_single", True,
+                         False, True)
+
+def benchmark_db_delete_index_all(run):
+    _benchmark_db_delete(run, "benchmark_delete_index_all", False, True, False)
+
+def benchmark_db_delete_batch_index_all(run):
+    _benchmark_db_delete(run, "benchmark_delete_batch_index_all", True, True,
+                         False)
+
+def benchmark_db_delete_index_mixed(run):
+    _benchmark_db_delete(run, "benchmark_delete_index_mixed", False, True, True)
+
+def benchmark_db_delete_batch_index_mixed(run):
+    _benchmark_db_delete(run, "benchmark_delete_batch_index_mixed", True, True,
+                         True)
+
+def _benchmark_db_delete(run, namespace, use_batch, use_index_all,
+                         use_index_single):
+    namespace_encoded = encode(namespace)
+    b_s_error_ptr = ffi.new("GError*")
+    b_s_error_ptr = ffi.NULL
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    b_scheme = _benchmark_db_prepare_scheme(namespace_encoded, False,
+                                            use_index_all, use_index_single,
+                                            batch, delete_batch)
+    assert b_scheme != ffi.NULL
+    assert run != None
+    _benchmark_db_insert(None, b_scheme, "\0", True, False, False, False)
+    run.start_timer()
+    iterations = N if use_index_all or use_index_single else int(N / N_GET_DIVIDER)
+    for i in range(iterations):
+        entry = lib.j_db_entry_new(b_scheme, b_s_error_ptr)
+        string = encode(_benchmark_db_get_identifier(i))
+        string_name = encode("string")
+        selector = lib.j_db_selector_new(b_scheme, lib.J_DB_SELECTOR_MODE_AND,
+                                         b_s_error_ptr)
+        assert lib.j_db_selector_add_field(selector, string_name,
+                                           lib.J_DB_SELECTOR_OPERATOR_EQ,
+                                           string, 0, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_entry_delete(entry, selector, batch, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_db_entry_unref(entry)
+        lib.j_db_selector_unref(selector)
+    if use_batch:
+            assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(delete_batch)
+    run.operations = iterations
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+    lib.j_db_schema_unref(b_scheme)
+
+def benchmark_db_update(run):
+    _benchmark_db_update(run, "benchmark_update", False, False, False)
+
+def benchmark_db_update_batch(run):
+    _benchmark_db_update(run, "benchmark_update_batch", True, False, False)
+
+def benchmark_db_update_index_single(run):
+    _benchmark_db_update(run, "benchmark_update_index_single", False, False,
+                         True)
+
+def benchmark_db_update_batch_index_single(run):
+    _benchmark_db_update(run, "benchmark_update_batch_index_single", True,
+                         False, True)
+
+def benchmark_db_update_index_all(run):
+    _benchmark_db_update(run, "benchmark_update_index_all", False, True, False)
+
+def benchmark_db_update_batch_index_all(run):
+    _benchmark_db_update(run, "benchmark_update_batch_index_all", True, True,
+                         False)
+
+def benchmark_db_update_index_mixed(run):
+    _benchmark_db_update(run, "benchmark_update_index_mixed", False, True, True)
+
+def benchmark_db_update_batch_index_mixed(run):
+    _benchmark_db_update(run, "benchmark_update_batch_index_mixed", True, True,
+                         True)
+
+def _benchmark_db_update(run, namespace, use_batch, use_index_all,
+                         use_index_single):
+    namespace_encoded = encode(namespace)
+    b_s_error_ptr = ffi.new("GError*")
+    b_s_error_ptr = ffi.NULL
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    b_scheme = _benchmark_db_prepare_scheme(namespace_encoded, False,
+                                            use_index_all, use_index_single,
+                                            batch, delete_batch)
+    assert b_scheme != ffi.NULL
+    assert run != None
+    _benchmark_db_insert(None, b_scheme, "\0", True, False, False, False)
+    run.start_timer()
+    iterations = N if use_index_all or use_index_single else int(N / N_GET_DIVIDER)
+    for i in range(iterations):
+        sint_name = encode("sint")
+        i_signed_ptr = ffi.new("long*")
+        i_signed_ptr[0] = (((i + N_PRIME) * SIGNED_FACTOR) & CLASS_MODULUS) - CLASS_LIMIT
+        selector = lib.j_db_selector_new(b_scheme, lib.J_DB_SELECTOR_MODE_AND,
+                                         b_s_error_ptr)
+        entry = lib.j_db_entry_new(b_scheme, b_s_error_ptr)
+        string_name = encode("string")
+        string = encode(_benchmark_db_get_identifier(i))
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_entry_set_field(encode, sint_name, i_signed_ptr, 0,
+                                        b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_selector_add_field(selector, string_name,
+                                           lib.J_DB_SELECTOR_OPERATOR_EQ,
+                                           string, 0, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_entry_update(entry, selector, batch, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_db_selector_unref(selector)
+        lib.j_db_entry_unref(entry)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(delete_batch)
+    run.operations = iterations
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+    lib.j_db_schema_unref(b_scheme)

--- a/benchmark/python/db/iterator.py
+++ b/benchmark/python/db/iterator.py
@@ -1,0 +1,130 @@
+from benchmarkrun import BenchmarkRun, append_to_benchmark_list_and_run
+from julea import lib, encode, ffi
+from db.common import _benchmark_db_prepare_scheme, _benchmark_db_insert, _benchmark_db_get_identifier, N, N_GET_DIVIDER, CLASS_MODULUS, CLASS_LIMIT
+
+def benchmark_db_iterator(benchmarkrun_list, iterations, machine_readable):
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/iterator/get-simple", iterations, machine_readable), benchmark_db_get_simple)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/iterator/get-simple-index-single", iterations, machine_readable), benchmark_db_get_simple_index_single)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/iterator/get-simple-index-all", iterations, machine_readable), benchmark_db_get_simple_index_all)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/iterator/get-simple-index-mixed", iterations, machine_readable), benchmark_db_get_simple_index_mixed)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/iterator/get-range", iterations, machine_readable), benchmark_db_get_range)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/iterator/get-range-index-single", iterations, machine_readable), benchmark_db_get_range_index_single)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/iterator/get-range-index-all", iterations, machine_readable), benchmark_db_get_range_index_all)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/iterator/get-range-index-mixed", iterations, machine_readable), benchmark_db_get_range_index_mixed)
+
+def benchmark_db_get_simple(run):
+    _benchmark_db_get_simple(run, "benchmark_get_simple", False, False)
+
+def benchmark_db_get_simple_index_single(run):
+    _benchmark_db_get_simple(run, "benchmark_get_simple_index_single", False,
+                             True)
+
+def benchmark_db_get_simple_index_all(run):
+    _benchmark_db_get_simple(run, "benchmark_get_simple_index_all", True, False)
+
+def benchmark_db_get_simple_index_mixed(run):
+    _benchmark_db_get_simple(run, "benchmark_get_simple_index_mixed", True, True)
+
+def _benchmark_db_get_simple(run, namespace, use_index_all, use_index_single):
+    namespace_encoded = encode(namespace)
+    b_s_error_ptr = ffi.new("GError*")
+    b_s_error_ptr = ffi.NULL
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    b_scheme = _benchmark_db_prepare_scheme(namespace_encoded, False,
+                                            use_index_all, use_index_single,
+                                            batch, delete_batch)
+    assert b_scheme != ffi.NULL
+    assert run != None
+    _benchmark_db_insert(None, b_scheme, "\0", True, False, False, False)
+    run.start_timer()
+    iterations = N if use_index_all or use_index_single else int(N / N_GET_DIVIDER)
+    for i in range(iterations):
+        field_type_ptr = ffi.new("JDBType*")
+        field_value_ptr = ffi.new("void**")
+        field_length_ptr = ffi.new("unsigned long*")
+        string_name = encode("string")
+        string = encode(_benchmark_db_get_identifier(i))
+        selector = lib.j_db_selector_new(b_scheme, lib.J_DB_SELECTOR_MODE_AND,
+                                         b_s_error_ptr)
+        assert lib.j_db_selector_add_field(selector, string_name,
+                                           lib.J_DB_SELECTOR_OPERATOR_EQ,
+                                           string, 0, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        iterator = lib.j_db_iterator_new(b_scheme, selector, b_s_error_ptr)
+        assert iterator != ffi.NULL
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_iterator_next(iterator, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_iterator_get_field(iterator, string_name, field_type_ptr,
+                                       field_value_ptr, field_length_ptr,
+                                       b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        lib.j_db_selector_unref(selector)
+        lib.j_db_iterator_unref(iterator)
+    run.operations = iterations
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+    lib.j_db_schema_unref(b_scheme)
+
+def benchmark_db_get_range(run):
+    _benchmark_db_get_range(run, "benchmark_get_range", False, False)
+
+def benchmark_db_get_range_index_single(run):
+    _benchmark_db_get_range(run, "benchmark_get_range_index_single", False,
+                             True)
+
+def benchmark_db_get_range_index_all(run):
+    _benchmark_db_get_range(run, "benchmark_get_range_index_all", True, False)
+
+def benchmark_db_get_range_index_mixed(run):
+    _benchmark_db_get_range(run, "benchmark_get_range_index_mixed", True, True)
+
+def _benchmark_db_get_range(run, namespace, use_index_all, use_index_single):
+    namespace_encoded = encode(namespace)
+    b_s_error_ptr = ffi.new("GError*")
+    b_s_error_ptr = ffi.NULL
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    b_scheme = _benchmark_db_prepare_scheme(namespace_encoded, False,
+                                            use_index_all, use_index_single,
+                                            batch, delete_batch)
+    assert b_scheme != ffi.NULL
+    assert run != None
+    _benchmark_db_insert(None, b_scheme, "\0", True, False, False, False)
+    run.start_timer()
+    for i in range(N_GET_DIVIDER):
+        field_type_ptr = ffi.new("JDBType*")
+        field_value_ptr = ffi.new("void**")
+        field_length_ptr = ffi.new("unsigned long*")
+        sint_name = encode("sint")
+        string_name = encode("string")
+        range_begin_ptr = ffi.new("long*")
+        range_begin_ptr[0] = int((i * (CLASS_MODULUS / N_GET_DIVIDER)) - CLASS_LIMIT)
+        range_end_ptr = ffi.new("long*")
+        range_end_ptr[0] = int(((i + 1) * (CLASS_MODULUS / N_GET_DIVIDER)) - (CLASS_LIMIT + 1))
+        selector = lib.j_db_selector_new(b_scheme, lib.J_DB_SELECTOR_MODE_AND,
+                                         b_s_error_ptr)
+        assert lib.j_db_selector_add_field(selector, sint_name,
+                                           lib.J_DB_SELECTOR_OPERATOR_GE,
+                                           range_begin_ptr, 0 , b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_selector_add_field(selector, sint_name,
+                                           lib.J_DB_SELECTOR_OPERATOR_LE,
+                                           range_end_ptr, 0, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        iterator = lib.j_db_iterator_new(b_scheme, selector, b_s_error_ptr)
+        assert iterator != ffi.NULL
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_iterator_next(iterator, b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+        assert lib.j_db_iterator_get_field(iterator, string_name, field_type_ptr,
+                                       field_value_ptr, field_length_ptr,
+                                       b_s_error_ptr)
+        assert b_s_error_ptr == ffi.NULL
+    run.stop_timer()
+    assert lib.j_batch_execute(delete_batch)
+    run.operations = N_GET_DIVIDER
+    lib.j_db_schema_unref(b_scheme)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)

--- a/benchmark/python/db/schema.py
+++ b/benchmark/python/db/schema.py
@@ -1,0 +1,78 @@
+from benchmarkrun import BenchmarkRun, append_to_benchmark_list_and_run
+from julea import lib, encode, ffi
+
+def benchmark_db_schema(benchmarkrun_list, iterations, machine_readable):
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/schema/create", iterations, machine_readable), benchmark_db_schema_create)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/schema/create-batch", iterations, machine_readable), benchmark_db_schema_create_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/schema/delete", iterations, machine_readable), benchmark_db_schema_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/db/schema/delete-batch", iterations, machine_readable), benchmark_db_schema_delete_batch)
+
+def benchmark_db_schema_create(run):
+    _benchmark_db_schema_create(run, False)
+
+def benchmark_db_schema_create_batch(run):
+    _benchmark_db_schema_create(run, True)
+
+def _benchmark_db_schema_create(run, use_batch):
+    run.iterations = int(run.iterations / 10)
+    run.operations = run.iterations
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        error_ptr = ffi.new("GError*")
+        error_ptr_ptr = ffi.new("GError**")
+        error_ptr_ptr[0] = error_ptr
+        name = encode(f"benchmark-schema-{i}")
+        namespace = encode("benchmark-ns")
+        schema = lib.j_db_schema_new(namespace, name, error_ptr_ptr)
+        for j in range(10):
+            fname = encode("field{j}")
+            lib.j_db_schema_add_field(schema, fname, lib.J_DB_TYPE_STRING,
+                                      error_ptr_ptr)
+        lib.j_db_schema_create(schema, batch, ffi.NULL)
+        lib.j_db_schema_delete(schema, delete_batch, ffi.NULL)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_db_schema_unref(schema)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(delete_batch)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+
+def benchmark_db_schema_delete(run):
+    _benchmark_db_schema_delete(run, False)
+
+def benchmark_db_schema_delete_batch(run):
+    _benchmark_db_schema_delete(run, True)
+
+def _benchmark_db_schema_delete(run, use_batch):
+    run.iterations = int(run.iterations / 10)
+    run.operations = run.iterations
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    for i in range(run.iterations):
+        name = encode(f"benchmark-schema-{i}")
+        namespace = encode("benchmark-ns")
+        schema = lib.j_db_schema_new(namespace, name, ffi.NULL)
+        for j in range(10):
+            fname = encode(f"field{j}")
+            lib.j_db_schema_add_field(schema, fname, lib.J_DB_TYPE_STRING,
+                                      ffi.NULL)
+        lib.j_db_schema_create(schema, batch, ffi.NULL)
+        lib.j_db_schema_unref(schema)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-schema-{i}")
+        namespace = encode("benchmark-ns")
+        schema = lib.j_db_schema_new(namespace, name, ffi.NULL)
+        lib.j_db_schema_delete(schema, batch, ffi.NULL)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_db_schema_unref(schema)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)

--- a/benchmark/python/item/collection.py
+++ b/benchmark/python/item/collection.py
@@ -1,0 +1,100 @@
+from benchmarkrun import BenchmarkRun, append_to_benchmark_list_and_run
+from julea import lib, encode, ffi
+
+def benchmark_collection(benchmarkrun_list, iterations, machine_readable):
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/collection/create", iterations, machine_readable), benchmark_collection_create)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/collection/create-batch", iterations, machine_readable), benchmark_collection_create_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/collection/delete", iterations, machine_readable), benchmark_collection_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/collection/delete-batch", iterations, machine_readable), benchmark_collection_delete_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/collection/delete-batch-without-get", iterations, machine_readable), benchmark_collection_delete_batch_without_get)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/collection/unordered-create-delete", iterations, machine_readable), benchmark_collection_unordered_create_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/collection/unordered-create-delete-batch", iterations, machine_readable), benchmark_collection_unordered_create_delete_batch)
+    # TODO: benchmark get (also missing in c benchmark)
+
+def benchmark_collection_create(run):
+    _benchmark_collection_create(run, False)
+
+def benchmark_collection_create_batch(run):
+    _benchmark_collection_create(run, True)
+
+def _benchmark_collection_create(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark{i}")
+        collection = lib.j_collection_create(name, batch)
+        lib.j_collection_delete(collection, delete_batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_collection_unref(collection)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(delete_batch)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+
+def benchmark_collection_delete(run):
+    _benchmark_collection_delete(run, False)
+
+def benchmark_collection_delete_batch(run):
+    _benchmark_collection_delete(run, True)
+
+def _benchmark_collection_delete(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        collection = lib.j_collection_create(name, batch)
+        lib.j_collection_unref(collection)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        collection_ptr = ffi.new("JCollection**")
+        name = encode(f"benchmark-{i}")
+        lib.j_collection_get(collection_ptr, name, batch)
+        assert lib.j_batch_execute(batch)
+        lib.j_collection_delete(collection_ptr[0], batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)
+
+def benchmark_collection_delete_batch_without_get(run):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        collection = lib.j_collection_create(name, batch)
+        lib.j_collection_delete(collection, delete_batch)
+        lib.j_collection_unref(collection)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    assert lib.j_batch_execute(delete_batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+
+def benchmark_collection_unordered_create_delete(run):
+    _benchmark_collection_unordered_create_delete(run, False)
+
+def benchmark_collection_unordered_create_delete_batch(run):
+    _benchmark_collection_unordered_create_delete(run, True)
+
+def _benchmark_collection_unordered_create_delete(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        collection = lib.j_collection_create(name, batch)
+        lib.j_collection_delete(collection, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_collection_unref(collection)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    run.operations = run.iterations * 2
+    lib.j_batch_unref(batch)

--- a/benchmark/python/item/item.py
+++ b/benchmark/python/item/item.py
@@ -1,0 +1,231 @@
+from benchmarkrun import BenchmarkRun, append_to_benchmark_list_and_run
+from julea import lib, encode, ffi
+
+def benchmark_item(benchmarkrun_list, iterations, machine_readable):
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/create", iterations, machine_readable), benchmark_item_create)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/create-batch", iterations, machine_readable), benchmark_item_create_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/delete", iterations, machine_readable), benchmark_item_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/delete-batch", iterations, machine_readable), benchmark_item_delete_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/delete-batch-without-get", iterations, machine_readable), benchmark_item_delete_batch_without_get)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/get-status", iterations, machine_readable), benchmark_item_get_status)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/get-status-batch", iterations, machine_readable), benchmark_item_get_status_batch)
+    # TODO: benchmark get (also missing in c benchmark)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/read", iterations, machine_readable), benchmark_item_read)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/read-batch", iterations, machine_readable), benchmark_item_read_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/write", iterations, machine_readable), benchmark_item_write)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/write-batch", iterations, machine_readable), benchmark_item_write_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/unordered-create-delete", iterations, machine_readable), benchmark_item_unordered_create_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/item/item/unordered-create-delete-batch", iterations, machine_readable), benchmark_item_unordered_create_delete_batch)
+
+def benchmark_item_create(run):
+    _benchmark_item_create(run, False)
+
+def benchmark_item_create_batch(run):
+    _benchmark_item_create(run, True)
+
+def _benchmark_item_create(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    collection_name = encode("benchmark")
+    collection = lib.j_collection_create(collection_name, batch)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        item = lib.j_item_create(collection, name, ffi.NULL, batch)
+        lib.j_item_delete(item, delete_batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_item_unref(item)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(delete_batch)
+    lib.j_collection_unref(collection)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+
+def benchmark_item_delete(run):
+    _benchmark_item_delete(run, False)
+
+def benchmark_item_delete_batch(run):
+    _benchmark_item_delete(run, True)
+
+def _benchmark_item_delete(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    get_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    collection_name = encode("benchmark")
+    collection = lib.j_collection_create(collection_name, batch)
+    assert lib.j_batch_execute(batch)
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        item = lib.j_item_create(collection, name, ffi.NULL, batch)
+        lib.j_item_unref(item)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        ptr = ffi.new("int**")
+        item_ptr = ffi.cast("JItem**", ptr)
+        name = encode(f"benchmark-{i}")
+        lib.j_item_get(collection, item_ptr, name, get_batch)
+        assert lib.j_batch_execute(get_batch)
+        lib.j_item_delete(item_ptr[0], batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_collection_delete(collection, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_collection_unref(collection)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(get_batch)
+
+def benchmark_item_delete_batch_without_get(run):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    delete_batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    collection_name = encode("benchmark")
+    collection = lib.j_collection_create(collection_name, batch)
+    assert lib.j_batch_execute(batch)
+    for i in range(run.iterations):
+        name = encode("benchmark-{i}")
+        item = lib.j_item_create(collection, name, ffi.NULL, batch)
+        lib.j_item_delete(item, delete_batch)
+        lib.j_item_unref(item)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    assert lib.j_batch_execute(delete_batch)
+    run.stop_timer()
+    lib.j_collection_delete(collection, batch)
+    lib.j_collection_unref(collection)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(delete_batch)
+
+def benchmark_item_get_status(run):
+    _benchmark_item_get_status(run, False)
+
+def benchmark_item_get_status_batch(run):
+    _benchmark_item_get_status(run, True)
+
+def _benchmark_item_get_status(run, use_batch):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    dummy = ffi.new("char[1]")
+    nb_ptr = ffi.new("unsigned long*")
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    collection_name = encode("benchmark")
+    collection = lib.j_collection_create(collection_name, batch)
+    item = lib.j_item_create(collection, collection_name, ffi.NULL, batch)
+    lib.j_item_write(item, dummy, 1, 0, nb_ptr, batch)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_item_get_status(item, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_item_delete(item, batch)
+    lib.j_collection_delete(collection, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_item_unref(item)
+    lib.j_collection_unref(collection)
+    lib.j_batch_unref(batch)
+
+def benchmark_item_read(run):
+    _benchmark_item_read(run, False, 4 * 1024)
+
+def benchmark_item_read_batch(run):
+    _benchmark_item_read(run, True, 4 * 1024)
+
+def _benchmark_item_read(run, use_batch, block_size):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    nb_ptr = ffi.new("unsigned long*")
+    dummy = ffi.new("char[]", block_size)
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    collection_name = encode("benchmark")
+    collection = lib.j_collection_create(collection_name, batch)
+    item = lib.j_item_create(collection, collection_name, ffi.NULL, batch)
+    for i in range(run.iterations):
+        lib.j_item_write(item, dummy, block_size, i * block_size, nb_ptr, batch)
+    assert lib.j_batch_execute(batch)
+    assert nb_ptr[0] == run.iterations * block_size
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_item_read(item, dummy, block_size, i * block_size, nb_ptr, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+            assert nb_ptr[0] == block_size
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+        assert nb_ptr[0] == run.iterations * block_size
+    run.stop_timer()
+    lib.j_item_delete(item, batch)
+    lib.j_collection_delete(collection, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_item_unref(item)
+    lib.j_collection_unref(collection)
+    lib.j_batch_unref(batch)
+
+def benchmark_item_write(run):
+    _benchmark_item_write(run, False, 4 * 1024)
+
+def benchmark_item_write_batch(run):
+    _benchmark_item_write(run, True, 4 * 1024)
+
+def _benchmark_item_write(run, use_batch, block_size):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    dummy = ffi.new("char[]", block_size)
+    nb_ptr = ffi.new("unsigned long*")
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    collection_name = encode("benchmark")
+    collection = lib.j_collection_create(collection_name, batch)
+    item = lib.j_item_create(collection, collection_name, ffi.NULL, batch)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_item_write(item, dummy, block_size, i * block_size, nb_ptr, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+            assert nb_ptr[0] == block_size
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+        assert nb_ptr[0] == run.iterations * block_size
+    run.stop_timer()
+    lib.j_item_delete(item, batch)
+    lib.j_collection_delete(collection, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_item_unref(item)
+    lib.j_collection_unref(collection)
+    lib.j_batch_unref(batch)
+
+def benchmark_item_unordered_create_delete(run):
+    _benchmark_item_unordered_create_delete(run, False)
+
+def benchmark_item_unordered_create_delete_batch(run):
+    _benchmark_item_unordered_create_delete(run, True)
+
+def _benchmark_item_unordered_create_delete(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    collection_name = encode("benchmark")
+    collection = lib.j_collection_create(collection_name, batch)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        item = lib.j_item_create(collection, name, ffi.NULL, batch)
+        lib.j_item_delete(item, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_item_unref(item)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_collection_delete(collection, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_collection_unref(collection)
+    lib.j_batch_unref(batch)
+    run.operations = run.iterations * 2

--- a/benchmark/python/kv/kv.py
+++ b/benchmark/python/kv/kv.py
@@ -1,0 +1,131 @@
+from benchmarkrun import BenchmarkRun, append_to_benchmark_list_and_run
+from julea import lib, encode, ffi
+
+def benchmark_kv(benchmarkrun_list, iterations, machine_readable):
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/kv/put", iterations, machine_readable), benchmark_kv_put)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/kv/put_batch", iterations, machine_readable), benchmark_kv_put_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/kv/get", iterations, machine_readable), benchmark_kv_get)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/kv/get-batch", iterations, machine_readable), benchmark_kv_get_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/kv/delete", iterations, machine_readable), benchmark_kv_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/kv/delete-batch", iterations, machine_readable), benchmark_kv_delete_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/kv/unordered_put_delete", iterations, machine_readable), benchmark_kv_unordered_put_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/kv/unordered_put_delete_batch", iterations, machine_readable), benchmark_kv_unordered_put_delete_batch)
+
+def benchmark_kv_put(run):
+    _benchmark_kv_put(run, False)
+
+def benchmark_kv_put_batch(run):
+    _benchmark_kv_put(run, True)
+
+def _benchmark_kv_put(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    deletebatch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        kv = lib.j_kv_new(namespace, name)
+        empty = encode("empty")
+        lib.j_kv_put(kv, empty, 6, ffi.NULL, batch)
+        lib.j_kv_delete(kv, deletebatch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_kv_unref(kv)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(deletebatch)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(deletebatch)
+
+def benchmark_kv_get(run):
+    _benchmark_kv_get(run, False)
+
+def benchmark_kv_get_batch(run):
+    _benchmark_kv_get(run, True)
+
+@ffi.def_extern()
+def cffi_j_kv_get_function(pointer1, integer, pointer2):
+    return
+
+def _benchmark_kv_get(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    deletebatch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        kv = lib.j_kv_new(namespace, name)
+        lib.j_kv_put(kv, name, len(name), ffi.NULL, batch)
+        lib.j_kv_delete(kv, deletebatch)
+        lib.j_kv_unref(kv)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        kv = lib.j_kv_new(namespace, name)
+        lib.j_kv_get_callback(kv, lib.cffi_j_kv_get_function, ffi.NULL, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_kv_unref(kv)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(deletebatch)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(deletebatch)
+
+def benchmark_kv_delete(run):
+    _benchmark_kv_delete(run, False)
+
+def benchmark_kv_delete_batch(run):
+    _benchmark_kv_delete(run, True)
+
+def _benchmark_kv_delete(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        kv = lib.j_kv_new(namespace, name)
+        empty = encode("empty")
+        lib.j_kv_put(kv, empty, 6, ffi.NULL, batch)
+        lib.j_kv_unref(kv)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        kv = lib.j_kv_new(namespace, name)
+        lib.j_kv_delete(kv, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_kv_unref(kv)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)
+
+def benchmark_kv_unordered_put_delete(run):
+    _benchmark_kv_unordered_put_delete(run, False)
+
+def benchmark_kv_unordered_put_delete_batch(run):
+    _benchmark_kv_unordered_put_delete(run, True)
+
+def _benchmark_kv_unordered_put_delete(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        kv = lib.j_kv_new(namespace, name)
+        empty = encode("empty")
+        lib.j_kv_put(kv, empty, 6, ffi.NULL, batch)
+        lib.j_kv_delete(kv, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_kv_unref(kv)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)
+    run.operations = run.iterations * 2

--- a/benchmark/python/object/distributed_object.py
+++ b/benchmark/python/object/distributed_object.py
@@ -1,0 +1,206 @@
+from benchmarkrun import BenchmarkRun, append_to_benchmark_list_and_run
+from julea import lib, encode, ffi
+
+def benchmark_distributed_object(benchmarkrun_list, iterations, machine_readable):
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/create", iterations, machine_readable), benchmark_distributed_object_create)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/create-batch", iterations, machine_readable), benchmark_distributed_object_create_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/delete", iterations, machine_readable), benchmark_distributed_object_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/delete-batch", iterations, machine_readable), benchmark_distributed_object_delete_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/status", iterations, machine_readable), benchmark_distributed_object_status)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/status-batch", iterations, machine_readable), benchmark_distributed_object_status_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/read", iterations, machine_readable), benchmark_distributed_object_read)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/read-batch", iterations, machine_readable), benchmark_distributed_object_read_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/write", iterations, machine_readable), benchmark_distributed_object_write)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/write-batch", iterations, machine_readable), benchmark_distributed_object_write_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/unordered-create-delete", iterations, machine_readable), benchmark_distributed_object_unordered_create_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/distributed_object/unordered-create-delete-batch", iterations, machine_readable), benchmark_distributed_object_unordered_create_delete_batch)
+
+def benchmark_distributed_object_create(run):
+    _benchmark_distributed_object_create(run, False)
+
+def benchmark_distributed_object_create_batch(run):
+    _benchmark_distributed_object_create(run, True)
+
+def _benchmark_distributed_object_create(run, use_batch):
+    distribution = lib.j_distribution_new(lib.J_DISTRIBUTION_ROUND_ROBIN)
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    deletebatch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        obj = lib.j_distributed_object_new(namespace, name, distribution)
+        lib.j_distributed_object_create(obj, batch)
+        lib.j_distributed_object_delete(obj, deletebatch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_distributed_object_unref(obj)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(deletebatch)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(deletebatch)
+    lib.j_distribution_unref(distribution)
+
+def benchmark_distributed_object_delete(run):
+    _benchmark_distributed_object_delete(run, False)
+
+def benchmark_distributed_object_delete_batch(run):
+    _benchmark_distributed_object_delete(run, True)
+
+def _benchmark_distributed_object_delete(run, use_batch):
+    distribution = lib.j_distribution_new(lib.J_DISTRIBUTION_ROUND_ROBIN)
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        obj = lib.j_distributed_object_new(namespace, name, distribution)
+        lib.j_distributed_object_create(obj, batch)
+        lib.j_distributed_object_unref(obj)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        obj = lib.j_distributed_object_new(namespace, name, distribution)
+        lib.j_distributed_object_delete(obj, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_distributed_object_unref(obj)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)
+    lib.j_distribution_unref(distribution)
+
+def benchmark_distributed_object_status(run):
+    _benchmark_distributed_object_status(run, False)
+    
+def benchmark_distributed_object_status_batch(run):
+    _benchmark_distributed_object_status(run, True)
+
+def _benchmark_distributed_object_status(run, use_batch):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    distribution = lib.j_distribution_new(lib.J_DISTRIBUTION_ROUND_ROBIN)
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    name = encode("benchmark")
+    obj = lib.j_distributed_object_new(name, name, distribution)
+    lib.j_distributed_object_create(obj, batch)
+    size_ptr = ffi.new("unsigned long*")
+    modification_time_ptr = ffi.new("long*")
+    character = encode("A")
+    lib.j_distributed_object_write(obj, character, 1, 0, size_ptr, batch)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_distributed_object_status(obj, modification_time_ptr, size_ptr, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_distributed_object_delete(obj, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_distributed_object_unref(obj)
+    lib.j_batch_unref(batch)
+    lib.j_distribution_unref(distribution)
+    
+def benchmark_distributed_object_read(run):
+    _benchmark_distributed_object_read(run, False, 4 * 1024)
+
+def benchmark_distributed_object_read_batch(run):
+    _benchmark_distributed_object_read(run, True, 4 * 1024)
+
+def _benchmark_distributed_object_read(run, use_batch, block_size):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    distribution = lib.j_distribution_new(lib.J_DISTRIBUTION_ROUND_ROBIN)
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    name = encode("benchmark")
+    obj = lib.j_distributed_object_new(name, name, distribution)
+    dummy = ffi.new("char[]", block_size)
+    size_ptr = ffi.new("unsigned long*")
+    lib.j_distributed_object_create(obj, batch)
+    for i in range(run.iterations):
+        lib.j_distributed_object_write(obj, dummy, block_size, i*block_size,
+                                       size_ptr, batch)
+    assert lib.j_batch_execute(batch)
+    assert size_ptr[0] == run.iterations * block_size
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_distributed_object_read(obj, dummy, block_size, i * block_size,
+                                      size_ptr, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+            assert size_ptr[0] == block_size
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+        assert size_ptr[0] == run.iterations * block_size
+    run.stop_timer()
+    lib.j_distributed_object_delete(obj, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_distribution_unref(distribution)
+    lib.j_batch_unref(batch)
+    lib.j_distributed_object_unref(obj)
+
+def benchmark_distributed_object_write(run):
+    _benchmark_distributed_object_write(run, False, 4 * 1024)
+
+def benchmark_distributed_object_write_batch(run):
+    _benchmark_distributed_object_write(run, True, 4 * 1024)
+
+def _benchmark_distributed_object_write(run, use_batch, block_size):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    distribution = lib.j_distribution_new(lib.J_DISTRIBUTION_ROUND_ROBIN)
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    name = encode("benchmark")
+    obj = lib.j_distributed_object_new(name, name, distribution)
+    lib.j_distributed_object_create(obj, batch)
+    dummy = ffi.new("char[]", block_size)
+    size_ptr = ffi.new("unsigned long*")
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_distributed_object_write(obj, dummy, block_size, i*block_size,
+                                       size_ptr, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+            assert size_ptr[0] == block_size
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+        assert size_ptr[0] == run.iterations * block_size
+    run.stop_timer()
+    lib.j_distributed_object_delete(obj, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_distributed_object_unref(obj)
+    lib.j_batch_unref(batch)
+    lib.j_distribution_unref(distribution)
+
+def benchmark_distributed_object_unordered_create_delete(run):
+    _benchmark_distributed_object_unordered_create_delete(run, False)
+
+def benchmark_distributed_object_unordered_create_delete_batch(run):
+    _benchmark_distributed_object_unordered_create_delete(run, True)
+
+def _benchmark_distributed_object_unordered_create_delete(run, use_batch):
+    distribution = lib.j_distribution_new(lib.J_DISTRIBUTION_ROUND_ROBIN)
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        namespace = encode("benchmark")
+        name = encode(f"benchmark-{i}")
+        obj = lib.j_distributed_object_new(namespace, name, distribution)
+        lib.j_distributed_object_create(obj, batch)
+        lib.j_distributed_object_delete(obj, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_distributed_object_unref(obj)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)
+    lib.j_distribution_unref(distribution)
+    run.operations = run.iterations * 2

--- a/benchmark/python/object/object.py
+++ b/benchmark/python/object/object.py
@@ -1,0 +1,194 @@
+from benchmarkrun import BenchmarkRun, append_to_benchmark_list_and_run
+from julea import lib, encode, ffi
+
+def benchmark_object(benchmarkrun_list, iterations, machine_readable):
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/create", iterations, machine_readable), benchmark_object_create)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/create-batch", iterations, machine_readable), benchmark_object_create_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/delete", iterations, machine_readable), benchmark_object_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/delete-batch", iterations, machine_readable), benchmark_object_delete_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/status", iterations, machine_readable), benchmark_object_status)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/status-batch", iterations, machine_readable), benchmark_object_status_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/read", iterations, machine_readable), benchmark_object_read)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/read-batch", iterations, machine_readable), benchmark_object_read_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/write", iterations, machine_readable), benchmark_object_write)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/write-batch", iterations, machine_readable), benchmark_object_write_batch)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/unordered-create-delete", iterations, machine_readable), benchmark_object_unordered_create_delete)
+    append_to_benchmark_list_and_run(benchmarkrun_list, BenchmarkRun("/object/object/unordered-create-delete-batch", iterations, machine_readable), benchmark_object_unordered_create_delete_batch)
+
+
+def benchmark_object_create(run):
+    _benchmark_object_create(run, False)
+
+def benchmark_object_create_batch(run):
+    _benchmark_object_create(run, True)
+
+def _benchmark_object_create(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    deletebatch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        obj = lib.j_object_new(namespace, name)
+        lib.j_object_create(obj, batch)
+        lib.j_object_delete(obj, deletebatch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_object_unref(obj)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    assert lib.j_batch_execute(deletebatch)
+    lib.j_batch_unref(batch)
+    lib.j_batch_unref(deletebatch)
+
+
+def benchmark_object_delete(run):
+    _benchmark_object_delete(run, False)
+
+def benchmark_object_delete_batch(run):
+    _benchmark_object_delete(run, True)
+
+def _benchmark_object_delete(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        obj = lib.j_object_new(namespace, name)
+        lib.j_object_create(obj, batch)
+        lib.j_object_unref(obj)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        obj = lib.j_object_new(namespace, name)
+        lib.j_object_delete(obj, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_object_unref(obj)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)
+
+def benchmark_object_status(run):
+    _benchmark_object_status(run, False)
+
+def benchmark_object_status_batch(run):
+    _benchmark_object_status(run, True)
+
+def _benchmark_object_status(run, use_batch):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    name = encode("benchmark")
+    obj = lib.j_object_new(name, name)
+    lib.j_object_create(obj, batch)
+    size_ptr = ffi.new("unsigned long*")
+    modification_time_ptr = ffi.new("long*")
+    character = encode("A")
+    lib.j_object_write(obj, character, 1, 0, size_ptr, batch)
+    assert lib.j_batch_execute(batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_object_status(obj, modification_time_ptr, size_ptr, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_object_delete(obj, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_object_unref(obj)
+    lib.j_batch_unref(batch)
+
+def benchmark_object_read(run):
+    _benchmark_object_read(run, False, 4 * 1024)
+
+def benchmark_object_read_batch(run):
+    _benchmark_object_read(run, True, 4 * 1024)
+
+def _benchmark_object_read(run, use_batch, block_size):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    dummy = ffi.new("char[]", block_size)
+    nb_ptr = ffi.new("unsigned long*")
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    name = encode("benchmark")
+    obj = lib.j_object_new(name, name)
+    lib.j_object_create(obj, batch)
+    for i in range(run.iterations):
+        lib.j_object_write(obj, dummy, block_size, i * block_size, nb_ptr,
+                           batch)
+    assert lib.j_batch_execute(batch)
+    assert nb_ptr[0] == run.iterations * block_size
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_object_read(obj, dummy, block_size, i * block_size, nb_ptr, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+            assert nb_ptr[0] == block_size
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+        assert nb_ptr[0] == run.iterations * block_size
+    run.stop_timer()
+    lib.j_object_delete(obj, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_object_unref(obj)
+    lib.j_batch_unref(batch)
+
+def benchmark_object_write(run):
+    _benchmark_object_write(run, False, 4 * 1024)
+    
+def benchmark_object_write_batch(run):
+    _benchmark_object_write(run, True, 4 * 1024)
+
+def _benchmark_object_write(run, use_batch, block_size):
+    run.iterations = 10 * run.iterations if use_batch else run.iterations
+    run.operations = run.iterations
+    dummy = ffi.new("char[]", block_size)
+    nb_ptr = ffi.new("unsigned long*")
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    name = encode("benchmark")
+    obj = lib.j_object_new(name, name)
+    lib.j_object_create(obj, batch)
+    run.start_timer()
+    for i in range(run.iterations):
+        lib.j_object_write(obj, dummy, block_size, i * block_size, nb_ptr,
+                           batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+            assert nb_ptr[0] == block_size
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+        assert nb_ptr[0] == run.iterations * block_size
+    run.stop_timer()
+    lib.j_object_delete(obj, batch)
+    assert lib.j_batch_execute(batch)
+    lib.j_object_unref(obj)
+    lib.j_batch_unref(batch)
+
+def benchmark_object_unordered_create_delete(run):
+    _benchmark_object_unordered_create_delete(run, False)
+
+def benchmark_object_unordered_create_delete_batch(run):
+    _benchmark_object_unordered_create_delete(run, True)
+
+def _benchmark_object_unordered_create_delete(run, use_batch):
+    batch = lib.j_batch_new_for_template(lib.J_SEMANTICS_TEMPLATE_DEFAULT)
+    run.start_timer()
+    for i in range(run.iterations):
+        name = encode(f"benchmark-{i}")
+        namespace = encode("benchmark")
+        obj = lib.j_object_new(namespace, name)
+        lib.j_object_create(obj, batch)
+        lib.j_object_delete(obj, batch)
+        if not use_batch:
+            assert lib.j_batch_execute(batch)
+        lib.j_object_unref(obj)
+    if use_batch:
+        assert lib.j_batch_execute(batch)
+    run.stop_timer()
+    lib.j_batch_unref(batch)
+    run.operations = run.iterations * 2

--- a/python/build.py
+++ b/python/build.py
@@ -1,0 +1,5 @@
+from build_helper import build, copy_main_module
+
+if __name__ == "__main__":
+    build(["julea", "julea-object", "julea-kv", "julea-db", "julea-item"])
+    copy_main_module()

--- a/python/build_helper.py
+++ b/python/build_helper.py
@@ -1,0 +1,133 @@
+from os import popen, system
+from os.path import dirname
+import cffi
+
+def create_header(filename, libraries):
+    content = """typedef int gint;
+typedef unsigned int guint;
+typedef gint gboolean;
+typedef char gchar;
+
+typedef unsigned short guint16;
+typedef signed int gint32;
+typedef unsigned int guint32;
+typedef signed long gint64;
+typedef unsigned long guint64;
+
+typedef void* gpointer;
+typedef const void *gconstpointer;
+
+typedef unsigned long gsize;
+
+typedef guint32 GQuark;
+
+typedef struct _GError GError;
+struct _GError
+{
+    GQuark  domain;
+    gint    code;
+    gchar  *message;
+};
+
+typedef    struct _GModule GModule;
+
+typedef struct _GInputStream GInputStream;
+typedef struct _GOutputStream GOutputStream;
+
+typedef struct _GKeyFile GKeyFile;
+
+typedef struct _GSocketConnection GSocketConnection;
+
+typedef void (*GDestroyNotify) (gpointer data);
+
+typedef struct _bson_t
+{
+    uint32_t    flags;
+    uint32_t    len;
+    uint8_t     padding[120];
+} bson_t;
+
+typedef struct JBatch JBatch;
+extern "Python" void cffi_j_kv_get_function(gpointer, guint32, gpointer);
+extern "Python" void cffi_j_batch_async_callback(JBatch*, gboolean, gpointer);
+
+"""
+    for library in libraries:
+        content+=f"#include <{library}.h>\n"
+    with open(filename, "w") as file:
+        file.write(content)
+
+def get_additional_compiler_flags(libraries, remove_sanitize=True):
+    flags_buffer = popen(f"pkg-config --cflags {' '.join(libraries)}")
+    flags = flags_buffer.read().strip().split(' ')
+    # remove duplicate parameters
+    flags = [*set(flags)]
+    if remove_sanitize:
+        for s in flags:
+            if "-fsanitize" in s:
+                flags.remove(s)
+    return flags
+
+def get_include_dirs(flags):
+    return [ str.strip("-I") for str in flags if "-I" in str ]
+
+def collect_julea(filename, libraries, debug = False):
+    temp_filename = "temp.h"
+    create_header(temp_filename, libraries)
+    includes = get_additional_compiler_flags(libraries)
+    flags = list(filter(lambda entry: not "dependencies" in entry, includes))
+    # create dummy headers for files intentionally not included
+    with open("glib.h", "w") as file:
+        file.write("")
+    with open("gmodule.h", "w") as file:
+        file.write("")
+    with open("bson.h", "w") as file:
+        file.write("")
+    system("mkdir -p gio")
+    with open("gio/gio.h", "w") as file:
+        file.write("")
+    # list of macros to be ignored
+    macros = [
+            "-D'G_DEFINE_AUTOPTR_CLEANUP_FUNC(x, y)='",
+            "-D'G_END_DECLS='",
+            "-D'G_BEGIN_DECLS='",
+            "-D'G_GNUC_WARN_UNUSED_RESULT='",
+            "-D'G_GNUC_PRINTF(x, y)='"
+            ]
+    # let preprocessor collect all declarations
+    system(f"gcc -E -P {' '.join(macros)} {temp_filename} -I. {' '.join(flags)} -o {filename}")
+    # remove temporary files needed to please the preprocessor
+    system(f"rm -rf glib.h gmodule.h bson.h gio {temp_filename}")
+
+def process(libs, tempheader, debug=False):
+    ffi = cffi.FFI()
+    libraryname = "julea_wrapper"
+    with open(tempheader, "r") as file:
+        header_content = file.read()
+    includes = get_additional_compiler_flags(libs+["glib-2.0"], remove_sanitize=True)
+    include_dirs = get_include_dirs(includes)
+    ffi.cdef(header_content, override=True)
+    outdir = f"{dirname(__file__)}/../bld/"
+    headerincludes = ""
+    for lib in libs:
+        headerincludes += f'#include "{lib}.h"\n'
+    ffi.set_source(
+            libraryname,
+            headerincludes,
+            libraries=libs+["kv-null"],
+            include_dirs=include_dirs,
+            library_dirs=[outdir],
+            extra_compile_args=includes,
+            extra_link_args=["-Wl,-rpath,."]
+            )
+    ffi.compile(tmpdir=outdir, verbose=debug)
+    if not debug:
+        system(f"rm -f {tempheader} {outdir+libraryname}.o {outdir+libraryname}.c")
+
+def copy_main_module():
+    system(f"cp {dirname(__file__)}/julea.py {dirname(__file__)}/../bld/julea.py")
+
+def build(include_libs, debug=False):
+    header_name = "header_julea.h"
+    collect_julea(header_name, include_libs, debug)
+    process(include_libs, header_name, debug)

--- a/python/cffi-requirements.txt
+++ b/python/cffi-requirements.txt
@@ -1,0 +1,2 @@
+cffi==1.15.1
+pycparser==2.21

--- a/python/example/Makefile
+++ b/python/example/Makefile
@@ -1,0 +1,8 @@
+run:
+	../../scripts/setup.sh start
+	python hello-world.py
+	../../scripts/setup.sh stop
+
+clean:
+	../../scripts/setup.sh stop
+	../../scripts/setup.sh clean

--- a/python/example/hello-world.py
+++ b/python/example/hello-world.py
@@ -1,0 +1,72 @@
+from julea import JBatchResult, JBatch, ffi, lib, encode, read_from_buffer
+
+if __name__ == "__main__":
+    try:
+        value_obj = encode("Hello Object!")
+        value_kv = encode("Hello Key-Value!")
+        value_db = encode("Hello Database!")
+
+        result = JBatchResult()
+        hello = encode("hello")
+        world = encode("world")
+        nbytes_ptr = ffi.new("unsigned long*")
+        _object = lib.j_object_new(hello, world)
+        kv = lib.j_kv_new(hello, world)
+        schema = lib.j_db_schema_new(hello, world, ffi.NULL)
+        lib.j_db_schema_add_field(schema, hello, lib.J_DB_TYPE_STRING, ffi.NULL)
+        entry = lib.j_db_entry_new(schema, ffi.NULL)
+
+        lib.j_db_entry_set_field(entry, hello, value_db, len(value_db), ffi.NULL)
+
+        with JBatch(result) as batch:
+            lib.j_object_create(_object, batch)
+            lib.j_object_write(_object, value_obj, len(value_obj), 0, nbytes_ptr, batch)
+            lib.j_kv_put(kv, value_kv, len(value_kv), ffi.NULL, batch)
+            lib.j_db_schema_create(schema, batch, ffi.NULL)
+            lib.j_db_entry_insert(entry, batch, ffi.NULL)
+
+        if result.IsSuccess:
+            result = JBatchResult()
+            buffer = ffi.new("gchar[]", 128)
+            with JBatch(result) as batch:
+                lib.j_object_read(_object, buffer, 128, 0, nbytes_ptr, batch)
+            if result.IsSuccess:
+                print(f"Object contains: '{read_from_buffer(buffer)}' ({nbytes_ptr[0]} bytes)")
+            with JBatch(result) as batch:
+                lib.j_object_delete(_object, batch)
+
+            result = JBatchResult()
+            with JBatch(result) as batch:
+                buffer_ptr = ffi.new("void**")
+                length = ffi.new("unsigned int *")
+                lib.j_kv_get(kv, buffer_ptr, length, batch)
+            if result.IsSuccess:
+                char_buff_ptr = ffi.cast("char**", buffer_ptr)
+                print(f"KV contains: '{read_from_buffer(char_buff_ptr[0])}' ({length[0]} bytes)")
+            with JBatch(result) as batch:
+                lib.j_kv_delete(kv, batch)
+
+            try:
+                selector = lib.j_db_selector_new(schema, lib.J_DB_SELECTOR_MODE_AND, ffi.NULL)
+                lib.j_db_selector_add_field(selector, hello, lib.J_DB_SELECTOR_OPERATOR_EQ, value_db, len(value_db), ffi.NULL)
+                iterator = lib.j_db_iterator_new(schema, selector, ffi.NULL)
+                
+                while lib.j_db_iterator_next(iterator, ffi.NULL):
+                    _type = ffi.new("JDBType *")
+                    db_field_ptr = ffi.new("void**")
+                    db_length_ptr = ffi.new("unsigned long*")
+                    lib.j_db_iterator_get_field(iterator, hello, _type, db_field_ptr, db_length_ptr, ffi.NULL)
+                    print(f"DB contains: '{read_from_buffer(db_field_ptr[0])}' ({db_length_ptr[0]} bytes)")
+
+            finally:
+                with JBatch(result) as batch:
+                    lib.j_db_entry_delete(entry, selector, batch, ffi.NULL)
+                    lib.j_db_schema_delete(schema, batch, ffi.NULL)
+                lib.j_db_selector_unref(selector)
+                lib.j_db_iterator_unref(iterator)
+
+    finally:
+        lib.j_kv_unref(kv)
+        lib.j_object_unref(_object)
+        lib.j_db_schema_unref(schema)
+        lib.j_db_entry_unref(entry)

--- a/python/julea.py
+++ b/python/julea.py
@@ -1,0 +1,50 @@
+from julea_wrapper import lib, ffi
+
+encoding = 'utf-8'
+
+def encode(string):
+    result = ffi.new('char[]', string.encode(encoding)) 
+    return result
+
+def read_from_buffer(buffer):
+    char = ffi.cast('char*', buffer)
+    bytearr = b''
+    i = 0
+    byte = char[i]
+    while byte != b'\x00':
+        bytearr += byte
+        i += 1
+        byte = char[i]
+    return bytearr.decode()
+
+class JBatchResult:
+    IsSuccess = False
+
+    def __init__(self):
+        pass
+
+    def Succeed(self):
+        self.IsSuccess = True
+
+    def Fail(self):
+        self.IsSuccess = False;
+
+class JBatch:
+    def __init__(self, result):
+        template = lib.J_SEMANTICS_TEMPLATE_DEFAULT
+        self.batch = lib.j_batch_new_for_template(template)
+        self.result = result
+
+    def __enter__(self):
+        return self.batch
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if lib.j_batch_execute(self.batch):
+            self.result.Succeed()
+        else:
+            self.result.Fail()
+        lib.j_batch_unref(self.batch)
+        if exc_type is not None:
+            return False
+        else:
+            return True

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -37,6 +37,7 @@ usage ()
 #export G_SLICE=debug-blocks
 
 set_path
+set_python_path
 set_library_path
 set_backend_path
 set_hdf_path

--- a/scripts/common
+++ b/scripts/common
@@ -65,6 +65,31 @@ set_path ()
 	export PATH
 }
 
+set_python_path()
+{
+	local build_dir
+	local old_python_path
+
+	build_dir="$(get_directory "${SELF_DIR}/..")/bld"
+	old_python_path="${PYTHONPATH}"
+
+	if test -n "${JULEA_PREFIX}"
+	then
+		PYTHONPATH="${JULEA_PREFIX}/bin"
+	else
+		test -d "${build_dir}" || error_build_directory_not_found
+
+		PYTHONPATH="${build_dir}"
+	fi
+
+	if test -n "${old_python_path}"
+	then
+		PYTHONPATH="${PYTHONPATH}:${old_python_path}"
+	fi
+
+	export PYTHONPATH
+}
+
 set_library_path ()
 {
 	local build_dir

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -53,6 +53,7 @@ fi
 JULEA_ENVIRONMENT=1
 
 set_path
+set_python_path
 set_library_path
 set_pkg_config_path
 set_backend_path

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -68,6 +68,7 @@ MODE="$1"
 #export G_MESSAGES_DEBUG=JULEA
 
 set_path
+set_python_path
 set_library_path
 set_backend_path
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -37,6 +37,7 @@ usage ()
 export G_SLICE=debug-blocks
 
 set_path
+set_python_path
 set_library_path
 set_backend_path
 set_hdf_path


### PR DESCRIPTION
automatically generated Python module using CFFI
includes example program and benchmarks

Building the python module could be integrated into the build script. It can be build by invoking
```
$ python python/build.py
```
The dependencies for the module are included in [cffi-requirements.txt](python/cffi-requirements.txt) and can be installed by invoking
```
$ pip install -r python/cffi-requirements.txt
```