### PR TITLE
Pseudo batch-less operations

### DIFF
--- a/include/core/jbatch.h
+++ b/include/core/jbatch.h
@@ -39,6 +39,16 @@ G_BEGIN_DECLS
 
 struct JBatch;
 
+/**
+ * Simulate batch-less operations.
+ *
+ * J_SINGLE_OP can be passed to operations instead of an actual batch.
+ * The operation will then be executed immediately and is finished after the call returns.
+ * Default semantic settings will be used for execution.
+ *
+ */
+#define J_SINGLE_OP NULL
+
 typedef struct JBatch JBatch;
 
 typedef void (*JBatchAsyncCallback)(JBatch*, gboolean, gpointer);
@@ -114,6 +124,8 @@ JSemantics* j_batch_get_semantics(JBatch* batch);
 /**
  * Adds a new operation to the batch.
  *
+ * Passing J_SINGLE_OP creates a temporary batch and calls j_batch_execute.
+ *
  * \private
  *
  * \code
@@ -122,7 +134,7 @@ JSemantics* j_batch_get_semantics(JBatch* batch);
  * \param batch     A batch.
  * \param operation An operation.
  **/
-void j_batch_add(JBatch* batch, JOperation* operation);
+gboolean j_batch_add(JBatch* batch, JOperation* operation);
 
 /**
  * Executes the batch.

--- a/include/core/jbatch.h
+++ b/include/core/jbatch.h
@@ -112,6 +112,8 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(JBatch, j_batch_unref)
 /**
  * Returns a batch's semantics.
  *
+ * The returned object must be freed using j_semantic_unref.
+ *
  * \code
  * \endcode
  *

--- a/include/db/jdb-entry.h
+++ b/include/db/jdb-entry.h
@@ -114,7 +114,6 @@ gboolean j_db_entry_set_field(JDBEntry* entry, gchar const* name, gconstpointer 
  * \param[out] error  A GError pointer. Will point to a GError object in case of failure.
  * \pre entry != NULL
  * \pre entry has a least 1 value set to not NULL
- * \pre batch != NULL
  *
  * \return TRUE on success, FALSE otherwise
  **/
@@ -134,7 +133,6 @@ gboolean j_db_entry_insert(JDBEntry* entry, JBatch* batch, GError** error);
  * \pre entry has a least 1 value set to not NULL
  * \pre selector != NULL
  * \pre selector matches at least 1 entry
- * \pre batch != NULL
  *
  * \return TRUE on success, FALSE otherwise
  **/
@@ -151,7 +149,6 @@ gboolean j_db_entry_update(JDBEntry* entry, JDBSelector* selector, JBatch* batch
  * \param[in] batch the batch to append this operation to
  * \param[out] error  A GError pointer. Will point to a GError object in case of failure.
  * \pre entry != NULL
- * \pre batch != NULL
  *
  * \return TRUE on success, FALSE otherwise
  **/

--- a/include/db/jdb-schema.h
+++ b/include/db/jdb-schema.h
@@ -159,7 +159,6 @@ gboolean j_db_schema_add_index(JDBSchema* schema, gchar const** names, GError** 
  *
  * \pre schema != NULL
  * \pre schema contains at least 1 variable
- * \pre batch != NULL
  *
  * \return TRUE on success, FALSE otherwise
  **/
@@ -174,7 +173,6 @@ gboolean j_db_schema_create(JDBSchema* schema, JBatch* batch, GError** error);
  *
  * \pre schema != NULL
  * \pre schema exists in the backend
- * \pre batch != NULL
  *
  * \return TRUE on success, FALSE otherwise
  **/
@@ -189,7 +187,6 @@ gboolean j_db_schema_get(JDBSchema* schema, JBatch* batch, GError** error);
  *
  * \pre schema != NULL
  * \pre schema exists in the backend
- * \pre batch != NULL
  *
  * \return TRUE on success, FALSE otherwise
  **/

--- a/include/item/jcollection.h
+++ b/include/item/jcollection.h
@@ -112,7 +112,7 @@ JCollection* j_collection_create(gchar const* name, JBatch* batch);
  * \param name       A name.
  * \param batch      A batch.
  **/
-void j_collection_get(JCollection** collection, gchar const* name, JBatch* batch);
+gboolean j_collection_get(JCollection** collection, gchar const* name, JBatch* batch);
 
 /**
  * Deletes a collection.
@@ -123,7 +123,7 @@ void j_collection_get(JCollection** collection, gchar const* name, JBatch* batch
  * \param collection A collection.
  * \param batch      A batch.
  **/
-void j_collection_delete(JCollection* collection, JBatch* batch);
+gboolean j_collection_delete(JCollection* collection, JBatch* batch);
 
 /**
  * @}

--- a/include/item/jitem.h
+++ b/include/item/jitem.h
@@ -129,7 +129,7 @@ JItem* j_item_create(JCollection* collection, gchar const* name, JDistribution* 
  * \param item       An item.
  * \param batch      A batch.
  **/
-void j_item_delete(JItem* item, JBatch* batch);
+gboolean j_item_delete(JItem* item, JBatch* batch);
 
 /**
  * Gets an item from a collection.
@@ -142,7 +142,7 @@ void j_item_delete(JItem* item, JBatch* batch);
  * \param name       A name.
  * \param batch      A batch.
  **/
-void j_item_get(JCollection* collection, JItem** item, gchar const* name, JBatch* batch);
+gboolean j_item_get(JCollection* collection, JItem** item, gchar const* name, JBatch* batch);
 
 /**
  * Reads an item.
@@ -157,7 +157,7 @@ void j_item_get(JCollection* collection, JItem** item, gchar const* name, JBatch
  * \param bytes_read Number of bytes read.
  * \param batch      A batch.
  **/
-void j_item_read(JItem* item, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch);
+gboolean j_item_read(JItem* item, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch);
 
 /**
  * Writes an item.
@@ -175,7 +175,7 @@ void j_item_read(JItem* item, gpointer data, guint64 length, guint64 offset, gui
  * \param bytes_written Number of bytes written.
  * \param batch         A batch.
  **/
-void j_item_write(JItem* item, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch);
+gboolean j_item_write(JItem* item, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch);
 
 /**
  * Get the status of an item.
@@ -186,7 +186,7 @@ void j_item_write(JItem* item, gconstpointer data, guint64 length, guint64 offse
  * \param item      An item.
  * \param batch     A batch.
  **/
-void j_item_get_status(JItem* item, JBatch* batch);
+gboolean j_item_get_status(JItem* item, JBatch* batch);
 
 /**
  * Returns an item's size.

--- a/include/kv/jkv.h
+++ b/include/kv/jkv.h
@@ -125,7 +125,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(JKV, j_kv_unref)
  * \param value_destroy A function to correctly free the stored data.
  * \param batch A batch.
  **/
-void j_kv_put(JKV* kv, gpointer value, guint32 value_len, GDestroyNotify value_destroy, JBatch* batch);
+gboolean j_kv_put(JKV* kv, gpointer value, guint32 value_len, GDestroyNotify value_destroy, JBatch* batch);
 
 /**
  * Deletes a key-value pair.
@@ -136,7 +136,7 @@ void j_kv_put(JKV* kv, gpointer value, guint32 value_len, GDestroyNotify value_d
  * \param kv     A JKV.
  * \param batch  A batch.
  **/
-void j_kv_delete(JKV* kv, JBatch* batch);
+gboolean j_kv_delete(JKV* kv, JBatch* batch);
 
 /**
  * Get a key-value pair.
@@ -149,7 +149,7 @@ void j_kv_delete(JKV* kv, JBatch* batch);
  * \param value_len A pointer to the length of the returned value buffer.
  * \param batch A batch.
  **/
-void j_kv_get(JKV* kv, gpointer* value, guint32* value_len, JBatch* batch);
+gboolean j_kv_get(JKV* kv, gpointer* value, guint32* value_len, JBatch* batch);
 
 /**
  * Get a key-value pair and execute a callback function once the pair is received.
@@ -162,7 +162,7 @@ void j_kv_get(JKV* kv, gpointer* value, guint32* value_len, JBatch* batch);
  * \param data      User defined data which will be passed to the callback function.
  * \param batch     A batch.
  **/
-void j_kv_get_callback(JKV* kv, JKVGetFunc func, gpointer data, JBatch* batch);
+gboolean j_kv_get_callback(JKV* kv, JKVGetFunc func, gpointer data, JBatch* batch);
 
 /**
  * @}

--- a/include/object/jdistributed-object.h
+++ b/include/object/jdistributed-object.h
@@ -102,7 +102,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(JDistributedObject, j_distributed_object_unref)
  *
  * \return A new object. Should be freed with j_distributed_object_unref().
  **/
-void j_distributed_object_create(JDistributedObject* object, JBatch* batch);
+gboolean j_distributed_object_create(JDistributedObject* object, JBatch* batch);
 
 /**
  * Deletes an object.
@@ -113,7 +113,7 @@ void j_distributed_object_create(JDistributedObject* object, JBatch* batch);
  * \param object     An object.
  * \param batch      A batch.
  **/
-void j_distributed_object_delete(JDistributedObject* object, JBatch* batch);
+gboolean j_distributed_object_delete(JDistributedObject* object, JBatch* batch);
 
 /**
  * Reads an object.
@@ -128,7 +128,7 @@ void j_distributed_object_delete(JDistributedObject* object, JBatch* batch);
  * \param bytes_read Number of bytes read.
  * \param batch      A batch.
  **/
-void j_distributed_object_read(JDistributedObject* object, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch);
+gboolean j_distributed_object_read(JDistributedObject* object, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch);
 
 /**
  * Writes an object.
@@ -146,7 +146,7 @@ void j_distributed_object_read(JDistributedObject* object, gpointer data, guint6
  * \param bytes_written Number of bytes written.
  * \param batch         A batch.
  **/
-void j_distributed_object_write(JDistributedObject* object, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch);
+gboolean j_distributed_object_write(JDistributedObject* object, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch);
 
 /**
  * Get the status of an object.
@@ -159,7 +159,7 @@ void j_distributed_object_write(JDistributedObject* object, gconstpointer data, 
  * \param size              The size of object.
  * \param batch             A batch.
  **/
-void j_distributed_object_status(JDistributedObject* object, gint64* modification_time, guint64* size, JBatch* batch);
+gboolean j_distributed_object_status(JDistributedObject* object, gint64* modification_time, guint64* size, JBatch* batch);
 
 /**
  * Sync an object.
@@ -170,7 +170,7 @@ void j_distributed_object_status(JDistributedObject* object, gint64* modificatio
  * \param object    An object.
  * \param batch     A batch.
  **/
-void j_distributed_object_sync(JDistributedObject* object, JBatch* batch);
+gboolean j_distributed_object_sync(JDistributedObject* object, JBatch* batch);
 
 /**
  * @}

--- a/include/object/jobject.h
+++ b/include/object/jobject.h
@@ -116,7 +116,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(JObject, j_object_unref)
  * \param batch        A batch.
  *
  **/
-void j_object_create(JObject* object, JBatch* batch);
+gboolean j_object_create(JObject* object, JBatch* batch);
 
 /**
  * Deletes an object.
@@ -127,7 +127,7 @@ void j_object_create(JObject* object, JBatch* batch);
  * \param object     An object.
  * \param batch      A batch.
  **/
-void j_object_delete(JObject* object, JBatch* batch);
+gboolean j_object_delete(JObject* object, JBatch* batch);
 
 /**
  * Reads an object.
@@ -142,7 +142,7 @@ void j_object_delete(JObject* object, JBatch* batch);
  * \param bytes_read Number of bytes read.
  * \param batch      A batch.
  **/
-void j_object_read(JObject* object, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch);
+gboolean j_object_read(JObject* object, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch);
 
 /**
  * Writes an object.
@@ -160,7 +160,7 @@ void j_object_read(JObject* object, gpointer data, guint64 length, guint64 offse
  * \param bytes_written Number of bytes written.
  * \param batch         A batch.
  **/
-void j_object_write(JObject* object, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch);
+gboolean j_object_write(JObject* object, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch);
 
 /**
  * Get the status of an object.
@@ -173,7 +173,7 @@ void j_object_write(JObject* object, gconstpointer data, guint64 length, guint64
  * \param size              The size of object.
  * \param batch             A batch.
  **/
-void j_object_status(JObject* object, gint64* modification_time, guint64* size, JBatch* batch);
+gboolean j_object_status(JObject* object, gint64* modification_time, guint64* size, JBatch* batch);
 
 /**
  * Sync an object.
@@ -184,7 +184,7 @@ void j_object_status(JObject* object, gint64* modification_time, guint64* size, 
  * \param object    An object.
  * \param batch     A batch.
  **/
-void j_object_sync(JObject* object, JBatch* batch);
+gboolean j_object_sync(JObject* object, JBatch* batch);
 
 /**
  * @}

--- a/lib/core/jbatch.c
+++ b/lib/core/jbatch.c
@@ -278,7 +278,7 @@ j_batch_get_semantics(JBatch* batch)
 	return batch->semantics;
 }
 
-void
+gboolean
 j_batch_add(JBatch* batch, JOperation* operation)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -286,7 +286,17 @@ j_batch_add(JBatch* batch, JOperation* operation)
 	g_return_if_fail(batch != NULL);
 	g_return_if_fail(operation != NULL);
 
+	// pseudo batch-less ops by passing J_SINGLE_OP
+	if (batch == J_SINGLE_OP)
+	{
+		g_autoptr(JBatch) tmp_batch = NULL;
+		tmp_batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT);
+		j_list_append(tmp_batch->list, operation);
+		return j_batch_execute(tmp_batch);
+	}
+
 	j_list_append(batch->list, operation);
+	return TRUE;
 }
 
 /* Internal */

--- a/lib/core/jbatch.c
+++ b/lib/core/jbatch.c
@@ -286,7 +286,7 @@ j_batch_add(JBatch* batch, JOperation* operation)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(operation != NULL);
+	g_return_val_if_fail(operation != NULL, FALSE);
 
 	// pseudo batch-less ops by passing J_SINGLE_OP
 	if (batch == J_SINGLE_OP)

--- a/lib/core/jbatch.c
+++ b/lib/core/jbatch.c
@@ -273,9 +273,12 @@ j_batch_get_semantics(JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_val_if_fail(batch != NULL, NULL);
+	if (batch == J_SINGLE_OP)
+	{
+		return j_semantics_new(J_SEMANTICS_TEMPLATE_DEFAULT);
+	}
 
-	return batch->semantics;
+	return j_semantics_ref(batch->semantics);
 }
 
 gboolean
@@ -283,7 +286,6 @@ j_batch_add(JBatch* batch, JOperation* operation)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(batch != NULL);
 	g_return_if_fail(operation != NULL);
 
 	// pseudo batch-less ops by passing J_SINGLE_OP

--- a/lib/db/jdb-entry.c
+++ b/lib/db/jdb-entry.c
@@ -177,7 +177,6 @@ j_db_entry_insert(JDBEntry* entry, JBatch* batch, GError** error)
 	J_TRACE_FUNCTION(NULL);
 
 	g_return_val_if_fail(entry != NULL, FALSE);
-	g_return_val_if_fail(batch != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (G_UNLIKELY(!j_db_internal_insert(entry, batch, error)))
@@ -199,7 +198,6 @@ j_db_entry_update(JDBEntry* entry, JDBSelector* selector, JBatch* batch, GError*
 	bson_t* bson;
 
 	g_return_val_if_fail(entry != NULL, FALSE);
-	g_return_val_if_fail(batch != NULL, FALSE);
 	g_return_val_if_fail(selector != NULL, FALSE);
 	g_return_val_if_fail(selector->schema == entry->schema, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -229,7 +227,6 @@ j_db_entry_delete(JDBEntry* entry, JDBSelector* selector, JBatch* batch, GError*
 	J_TRACE_FUNCTION(NULL);
 
 	g_return_val_if_fail(entry != NULL, FALSE);
-	g_return_val_if_fail(batch != NULL, FALSE);
 	g_return_val_if_fail((selector == NULL) || (selector->schema == entry->schema), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 

--- a/lib/db/jdb-internal.c
+++ b/lib/db/jdb-internal.c
@@ -190,9 +190,7 @@ j_db_internal_schema_create(JDBSchema* j_db_schema, JBatch* batch, GError** erro
 	op->exec_func = j_db_schema_create_exec;
 	op->free_func = j_backend_db_func_free;
 
-	j_batch_add(batch, op);
-
-	return TRUE;
+	return j_batch_add(batch, op);
 }
 
 static gboolean
@@ -230,9 +228,7 @@ j_db_internal_schema_get(JDBSchema* j_db_schema, JBatch* batch, GError** error)
 	op->exec_func = j_db_schema_get_exec;
 	op->free_func = j_backend_db_func_free;
 
-	j_batch_add(batch, op);
-
-	return TRUE;
+	return j_batch_add(batch, op);
 }
 
 static gboolean
@@ -269,9 +265,7 @@ j_db_internal_schema_delete(JDBSchema* j_db_schema, JBatch* batch, GError** erro
 	op->exec_func = j_db_schema_delete_exec;
 	op->free_func = j_backend_db_func_free;
 
-	j_batch_add(batch, op);
-
-	return TRUE;
+	return j_batch_add(batch, op);
 }
 
 static gboolean
@@ -310,9 +304,7 @@ j_db_internal_insert(JDBEntry* j_db_entry, JBatch* batch, GError** error)
 	op->exec_func = j_db_insert_exec;
 	op->free_func = j_backend_db_func_free;
 
-	j_batch_add(batch, op);
-
-	return TRUE;
+	return j_batch_add(batch, op);
 }
 
 static gboolean
@@ -353,9 +345,7 @@ j_db_internal_update(JDBEntry* j_db_entry, JDBSelector* j_db_selector, JBatch* b
 	op->exec_func = j_db_update_exec;
 	op->free_func = j_backend_db_func_free;
 
-	j_batch_add(batch, op);
-
-	return TRUE;
+	return j_batch_add(batch, op);
 }
 
 static gboolean
@@ -395,9 +385,7 @@ j_db_internal_delete(JDBEntry* j_db_entry, JDBSelector* j_db_selector, JBatch* b
 	op->exec_func = j_db_delete_exec;
 	op->free_func = j_backend_db_func_free;
 
-	j_batch_add(batch, op);
-
-	return TRUE;
+	return j_batch_add(batch, op);
 }
 
 static gboolean
@@ -446,9 +434,7 @@ j_db_internal_query(JDBSchema* j_db_schema, JDBSelector* j_db_selector, JDBItera
 	op->exec_func = j_db_query_exec;
 	op->free_func = j_backend_db_func_free;
 
-	j_batch_add(batch, op);
-
-	return TRUE;
+	return j_batch_add(batch, op);
 }
 
 gboolean

--- a/lib/db/jdb-schema.c
+++ b/lib/db/jdb-schema.c
@@ -405,7 +405,6 @@ j_db_schema_create(JDBSchema* schema, JBatch* batch, GError** error)
 	J_TRACE_FUNCTION(NULL);
 
 	g_return_val_if_fail(schema != NULL, FALSE);
-	g_return_val_if_fail(batch != NULL, FALSE);
 	g_return_val_if_fail(!schema->server_side, FALSE);
 	g_return_val_if_fail(schema->bson_initialized, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -437,7 +436,6 @@ j_db_schema_get(JDBSchema* schema, JBatch* batch, GError** error)
 	J_TRACE_FUNCTION(NULL);
 
 	g_return_val_if_fail(schema != NULL, FALSE);
-	g_return_val_if_fail(batch != NULL, FALSE);
 	g_return_val_if_fail(!schema->server_side, FALSE);
 	g_return_val_if_fail(!schema->bson_initialized, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -462,7 +460,6 @@ j_db_schema_delete(JDBSchema* schema, JBatch* batch, GError** error)
 	J_TRACE_FUNCTION(NULL);
 
 	g_return_val_if_fail(schema != NULL, FALSE);
-	g_return_val_if_fail(batch != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (G_UNLIKELY(!j_db_internal_schema_delete(schema, batch, error)))

--- a/lib/item/jcollection.c
+++ b/lib/item/jcollection.c
@@ -158,7 +158,6 @@ gboolean
 j_collection_delete(JCollection* collection, JBatch* batch)
 {
 	g_return_if_fail(collection != NULL);
-	g_return_if_fail(batch != NULL);
 
 	return j_kv_delete(collection->kv, batch);
 }

--- a/lib/item/jcollection.c
+++ b/lib/item/jcollection.c
@@ -147,8 +147,8 @@ j_collection_get(JCollection** collection, gchar const* name, JBatch* batch)
 {
 	g_autoptr(JKV) kv = NULL;
 
-	g_return_if_fail(collection != NULL);
-	g_return_if_fail(name != NULL);
+	g_return_val_if_fail(collection != NULL, FALSE);
+	g_return_val_if_fail(name != NULL, FALSE);
 
 	kv = j_kv_new("collections", name);
 	return j_kv_get_callback(kv, j_collection_get_callback, collection, batch);
@@ -157,7 +157,7 @@ j_collection_get(JCollection** collection, gchar const* name, JBatch* batch)
 gboolean
 j_collection_delete(JCollection* collection, JBatch* batch)
 {
-	g_return_if_fail(collection != NULL);
+	g_return_val_if_fail(collection != NULL, FALSE);
 
 	return j_kv_delete(collection->kv, batch);
 }

--- a/lib/item/jcollection.c
+++ b/lib/item/jcollection.c
@@ -142,7 +142,7 @@ j_collection_get_callback(gpointer value, guint32 len, gpointer data)
 	g_free(value);
 }
 
-void
+gboolean
 j_collection_get(JCollection** collection, gchar const* name, JBatch* batch)
 {
 	g_autoptr(JKV) kv = NULL;
@@ -151,16 +151,16 @@ j_collection_get(JCollection** collection, gchar const* name, JBatch* batch)
 	g_return_if_fail(name != NULL);
 
 	kv = j_kv_new("collections", name);
-	j_kv_get_callback(kv, j_collection_get_callback, collection, batch);
+	return j_kv_get_callback(kv, j_collection_get_callback, collection, batch);
 }
 
-void
+gboolean
 j_collection_delete(JCollection* collection, JBatch* batch)
 {
 	g_return_if_fail(collection != NULL);
 	g_return_if_fail(batch != NULL);
 
-	j_kv_delete(collection->kv, batch);
+	return j_kv_delete(collection->kv, batch);
 }
 
 /* Internal */

--- a/lib/item/jitem.c
+++ b/lib/item/jitem.c
@@ -224,9 +224,9 @@ j_item_get(JCollection* collection, JItem** item, gchar const* name, JBatch* bat
 	g_autoptr(JKV) kv = NULL;
 	g_autofree gchar* path = NULL;
 
-	g_return_if_fail(collection != NULL);
-	g_return_if_fail(item != NULL);
-	g_return_if_fail(name != NULL);
+	g_return_val_if_fail(collection != NULL, FALSE);
+	g_return_val_if_fail(item != NULL, FALSE);
+	g_return_val_if_fail(name != NULL, FALSE);
 
 	data = g_slice_new(JItemGetData);
 	data->collection = j_collection_ref(collection);
@@ -244,7 +244,7 @@ j_item_delete(JItem* item, JBatch* batch)
 
 	gboolean ret = TRUE;
 
-	g_return_if_fail(item != NULL);
+	g_return_val_if_fail(item != NULL, FALSE);
 
 	ret &= j_kv_delete(item->kv, batch);
 	ret &= j_distributed_object_delete(item->object, batch);
@@ -257,9 +257,9 @@ j_item_read(JItem* item, gpointer data, guint64 length, guint64 offset, guint64*
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(item != NULL);
-	g_return_if_fail(data != NULL);
-	g_return_if_fail(bytes_read != NULL);
+	g_return_val_if_fail(item != NULL, FALSE);
+	g_return_val_if_fail(data != NULL, FALSE);
+	g_return_val_if_fail(bytes_read != NULL, FALSE);
 
 	return j_distributed_object_read(item->object, data, length, offset, bytes_read, batch);
 }
@@ -269,9 +269,9 @@ j_item_write(JItem* item, gconstpointer data, guint64 length, guint64 offset, gu
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(item != NULL);
-	g_return_if_fail(data != NULL);
-	g_return_if_fail(bytes_written != NULL);
+	g_return_val_if_fail(item != NULL, FALSE);
+	g_return_val_if_fail(data != NULL, FALSE);
+	g_return_val_if_fail(bytes_written != NULL, FALSE);
 
 	/// \todo see j_item_write_exec
 
@@ -283,7 +283,7 @@ j_item_get_status(JItem* item, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(item != NULL);
+	g_return_val_if_fail(item != NULL, FALSE);
 
 	/// \todo check j_item_get_status_exec
 	return j_distributed_object_status(item->object, &(item->status.modification_time), &(item->status.size), batch);

--- a/lib/item/jitem.c
+++ b/lib/item/jitem.c
@@ -180,10 +180,21 @@ j_item_create(JCollection* collection, gchar const* name, JDistribution* distrib
 	tmp = j_item_serialize(item, j_batch_get_semantics(batch));
 	value = bson_destroy_with_steal(tmp, TRUE, &len);
 
-	j_distributed_object_create(item->object, batch);
-	j_kv_put(item->kv, value, len, bson_free, batch);
+	if (!j_distributed_object_create(item->object, batch))
+	{
+		goto _error;
+	}
+
+	if (!j_kv_put(item->kv, value, len, bson_free, batch))
+	{
+		goto _error;
+	}
 
 	return item;
+
+_error:
+	j_item_unref(item);
+	return NULL;
 }
 
 static void
@@ -201,7 +212,7 @@ j_item_get_callback(gpointer value, guint32 len, gpointer data_)
 	g_free(value);
 }
 
-void
+gboolean
 j_item_get(JCollection* collection, JItem** item, gchar const* name, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -220,22 +231,26 @@ j_item_get(JCollection* collection, JItem** item, gchar const* name, JBatch* bat
 
 	path = g_build_path("/", j_collection_get_name(collection), name, NULL);
 	kv = j_kv_new("items", path);
-	j_kv_get_callback(kv, j_item_get_callback, data, batch);
+	return j_kv_get_callback(kv, j_item_get_callback, data, batch);
 }
 
-void
+gboolean
 j_item_delete(JItem* item, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
 
+	gboolean ret = TRUE;
+
 	g_return_if_fail(item != NULL);
 	g_return_if_fail(batch != NULL);
 
-	j_kv_delete(item->kv, batch);
-	j_distributed_object_delete(item->object, batch);
+	ret &= j_kv_delete(item->kv, batch);
+	ret &= j_distributed_object_delete(item->object, batch);
+
+	return ret;
 }
 
-void
+gboolean
 j_item_read(JItem* item, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -244,10 +259,10 @@ j_item_read(JItem* item, gpointer data, guint64 length, guint64 offset, guint64*
 	g_return_if_fail(data != NULL);
 	g_return_if_fail(bytes_read != NULL);
 
-	j_distributed_object_read(item->object, data, length, offset, bytes_read, batch);
+	return j_distributed_object_read(item->object, data, length, offset, bytes_read, batch);
 }
 
-void
+gboolean
 j_item_write(JItem* item, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -258,10 +273,10 @@ j_item_write(JItem* item, gconstpointer data, guint64 length, guint64 offset, gu
 
 	/// \todo see j_item_write_exec
 
-	j_distributed_object_write(item->object, data, length, offset, bytes_written, batch);
+	return j_distributed_object_write(item->object, data, length, offset, bytes_written, batch);
 }
 
-void
+gboolean
 j_item_get_status(JItem* item, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -269,7 +284,7 @@ j_item_get_status(JItem* item, JBatch* batch)
 	g_return_if_fail(item != NULL);
 
 	/// \todo check j_item_get_status_exec
-	j_distributed_object_status(item->object, &(item->status.modification_time), &(item->status.size), batch);
+	return j_distributed_object_status(item->object, &(item->status.modification_time), &(item->status.size), batch);
 }
 
 guint64

--- a/lib/item/jitem.c
+++ b/lib/item/jitem.c
@@ -168,6 +168,7 @@ j_item_create(JCollection* collection, gchar const* name, JDistribution* distrib
 	bson_t* tmp;
 	gpointer value;
 	guint32 len;
+	g_autoptr(JSemantics) semantics = NULL;
 
 	g_return_val_if_fail(collection != NULL, NULL);
 	g_return_val_if_fail(name != NULL, NULL);
@@ -177,7 +178,9 @@ j_item_create(JCollection* collection, gchar const* name, JDistribution* distrib
 		return NULL;
 	}
 
-	tmp = j_item_serialize(item, j_batch_get_semantics(batch));
+	semantics = j_batch_get_semantics(batch);
+
+	tmp = j_item_serialize(item, semantics);
 	value = bson_destroy_with_steal(tmp, TRUE, &len);
 
 	if (!j_distributed_object_create(item->object, batch))
@@ -242,7 +245,6 @@ j_item_delete(JItem* item, JBatch* batch)
 	gboolean ret = TRUE;
 
 	g_return_if_fail(item != NULL);
-	g_return_if_fail(batch != NULL);
 
 	ret &= j_kv_delete(item->kv, batch);
 	ret &= j_distributed_object_delete(item->object, batch);

--- a/lib/kv/jkv.c
+++ b/lib/kv/jkv.c
@@ -595,7 +595,7 @@ j_kv_unref(JKV* kv)
 	}
 }
 
-void
+gboolean
 j_kv_put(JKV* kv, gpointer value, guint32 value_len, GDestroyNotify value_destroy, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -618,10 +618,10 @@ j_kv_put(JKV* kv, gpointer value, guint32 value_len, GDestroyNotify value_destro
 	operation->exec_func = j_kv_put_exec;
 	operation->free_func = j_kv_put_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_kv_delete(JKV* kv, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -636,10 +636,10 @@ j_kv_delete(JKV* kv, JBatch* batch)
 	operation->exec_func = j_kv_delete_exec;
 	operation->free_func = j_kv_delete_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_kv_get(JKV* kv, gpointer* value, guint32* value_len, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -662,10 +662,10 @@ j_kv_get(JKV* kv, gpointer* value, guint32* value_len, JBatch* batch)
 	operation->exec_func = j_kv_get_exec;
 	operation->free_func = j_kv_get_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_kv_get_callback(JKV* kv, JKVGetFunc func, gpointer data, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -689,7 +689,7 @@ j_kv_get_callback(JKV* kv, JKVGetFunc func, gpointer data, JBatch* batch)
 	operation->exec_func = j_kv_get_exec;
 	operation->free_func = j_kv_get_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
 /**

--- a/lib/kv/jkv.c
+++ b/lib/kv/jkv.c
@@ -603,7 +603,7 @@ j_kv_put(JKV* kv, gpointer value, guint32 value_len, GDestroyNotify value_destro
 	JKVOperation* kop;
 	JOperation* operation;
 
-	g_return_if_fail(kv != NULL);
+	g_return_val_if_fail(kv != NULL, FALSE);
 
 	kop = g_slice_new(JKVOperation);
 	kop->put.kv = j_kv_ref(kv);
@@ -628,7 +628,7 @@ j_kv_delete(JKV* kv, JBatch* batch)
 
 	JOperation* operation;
 
-	g_return_if_fail(kv != NULL);
+	g_return_val_if_fail(kv != NULL, FALSE);
 
 	operation = j_operation_new();
 	operation->key = kv;
@@ -647,7 +647,7 @@ j_kv_get(JKV* kv, gpointer* value, guint32* value_len, JBatch* batch)
 	JKVOperation* kop;
 	JOperation* operation;
 
-	g_return_if_fail(kv != NULL);
+	g_return_val_if_fail(kv != NULL, FALSE);
 
 	kop = g_slice_new(JKVOperation);
 	kop->get.kv = j_kv_ref(kv);
@@ -673,8 +673,8 @@ j_kv_get_callback(JKV* kv, JKVGetFunc func, gpointer data, JBatch* batch)
 	JKVOperation* kop;
 	JOperation* operation;
 
-	g_return_if_fail(kv != NULL);
-	g_return_if_fail(func != NULL);
+	g_return_val_if_fail(kv != NULL, FALSE);
+	g_return_val_if_fail(func != NULL, FALSE);
 
 	kop = g_slice_new(JKVOperation);
 	kop->get.kv = j_kv_ref(kv);

--- a/lib/object/jdistributed-object.c
+++ b/lib/object/jdistributed-object.c
@@ -1421,7 +1421,7 @@ j_distributed_object_create(JDistributedObject* object, JBatch* batch)
 
 	JOperation* operation;
 
-	g_return_if_fail(object != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
 
 	operation = j_operation_new();
 	/// \todo key = index + namespace
@@ -1440,7 +1440,7 @@ j_distributed_object_delete(JDistributedObject* object, JBatch* batch)
 
 	JOperation* operation;
 
-	g_return_if_fail(object != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
 
 	operation = j_operation_new();
 	operation->key = object;
@@ -1461,10 +1461,10 @@ j_distributed_object_read(JDistributedObject* object, gpointer data, guint64 len
 	guint64 max_operation_size;
 	gboolean ret = TRUE;
 
-	g_return_if_fail(object != NULL);
-	g_return_if_fail(data != NULL);
-	g_return_if_fail(length > 0);
-	g_return_if_fail(bytes_read != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
+	g_return_val_if_fail(data != NULL, FALSE);
+	g_return_val_if_fail(length > 0, FALSE);
+	g_return_val_if_fail(bytes_read != NULL, FALSE);
 
 	max_operation_size = j_configuration_get_max_operation_size(j_configuration());
 
@@ -1510,10 +1510,10 @@ j_distributed_object_write(JDistributedObject* object, gconstpointer data, guint
 	guint64 max_operation_size;
 	gboolean ret = TRUE;
 
-	g_return_if_fail(object != NULL);
-	g_return_if_fail(data != NULL);
-	g_return_if_fail(length > 0);
-	g_return_if_fail(bytes_written != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
+	g_return_val_if_fail(data != NULL, FALSE);
+	g_return_val_if_fail(length > 0, FALSE);
+	g_return_val_if_fail(bytes_written != NULL, FALSE);
 
 	max_operation_size = j_configuration_get_max_operation_size(j_configuration());
 
@@ -1557,7 +1557,7 @@ j_distributed_object_status(JDistributedObject* object, gint64* modification_tim
 	JDistributedObjectOperation* iop;
 	JOperation* operation;
 
-	g_return_if_fail(object != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
 
 	iop = g_slice_new(JDistributedObjectOperation);
 	iop->status.object = j_distributed_object_ref(object);
@@ -1581,7 +1581,7 @@ j_distributed_object_sync(JDistributedObject* object, JBatch* batch)
 	JDistributedObjectOperation* iop;
 	JOperation* operation;
 
-	g_return_if_fail(object != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
 
 	iop = g_slice_new(JDistributedObjectOperation);
 	iop->sync.object = j_distributed_object_ref(object);

--- a/lib/object/jdistributed-object.c
+++ b/lib/object/jdistributed-object.c
@@ -1414,7 +1414,7 @@ j_distributed_object_unref(JDistributedObject* object)
 	}
 }
 
-void
+gboolean
 j_distributed_object_create(JDistributedObject* object, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1430,10 +1430,10 @@ j_distributed_object_create(JDistributedObject* object, JBatch* batch)
 	operation->exec_func = j_distributed_object_create_exec;
 	operation->free_func = j_distributed_object_create_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_distributed_object_delete(JDistributedObject* object, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1448,10 +1448,10 @@ j_distributed_object_delete(JDistributedObject* object, JBatch* batch)
 	operation->exec_func = j_distributed_object_delete_exec;
 	operation->free_func = j_distributed_object_delete_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_distributed_object_read(JDistributedObject* object, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1459,6 +1459,7 @@ j_distributed_object_read(JDistributedObject* object, gpointer data, guint64 len
 	JDistributedObjectOperation* iop;
 	JOperation* operation;
 	guint64 max_operation_size;
+	gboolean ret = TRUE;
 
 	g_return_if_fail(object != NULL);
 	g_return_if_fail(data != NULL);
@@ -1487,7 +1488,7 @@ j_distributed_object_read(JDistributedObject* object, gpointer data, guint64 len
 		operation->exec_func = j_distributed_object_read_exec;
 		operation->free_func = j_distributed_object_read_free;
 
-		j_batch_add(batch, operation);
+		ret &= j_batch_add(batch, operation);
 
 		data = (gchar*)data + chunk_size;
 		length -= chunk_size;
@@ -1495,9 +1496,11 @@ j_distributed_object_read(JDistributedObject* object, gpointer data, guint64 len
 	}
 
 	*bytes_read = 0;
+
+	return ret;
 }
 
-void
+gboolean
 j_distributed_object_write(JDistributedObject* object, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1505,6 +1508,7 @@ j_distributed_object_write(JDistributedObject* object, gconstpointer data, guint
 	JDistributedObjectOperation* iop;
 	JOperation* operation;
 	guint64 max_operation_size;
+	gboolean ret = TRUE;
 
 	g_return_if_fail(object != NULL);
 	g_return_if_fail(data != NULL);
@@ -1533,7 +1537,7 @@ j_distributed_object_write(JDistributedObject* object, gconstpointer data, guint
 		operation->exec_func = j_distributed_object_write_exec;
 		operation->free_func = j_distributed_object_write_free;
 
-		j_batch_add(batch, operation);
+		ret &= j_batch_add(batch, operation);
 
 		data = (gchar const*)data + chunk_size;
 		length -= chunk_size;
@@ -1541,9 +1545,11 @@ j_distributed_object_write(JDistributedObject* object, gconstpointer data, guint
 	}
 
 	*bytes_written = 0;
+
+	return ret;
 }
 
-void
+gboolean
 j_distributed_object_status(JDistributedObject* object, gint64* modification_time, guint64* size, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1564,10 +1570,10 @@ j_distributed_object_status(JDistributedObject* object, gint64* modification_tim
 	operation->exec_func = j_distributed_object_status_exec;
 	operation->free_func = j_distributed_object_status_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_distributed_object_sync(JDistributedObject* object, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1586,7 +1592,7 @@ j_distributed_object_sync(JDistributedObject* object, JBatch* batch)
 	operation->exec_func = j_distributed_object_sync_exec;
 	operation->free_func = j_distributed_object_sync_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
 /**

--- a/lib/object/jobject.c
+++ b/lib/object/jobject.c
@@ -1021,7 +1021,7 @@ j_object_unref(JObject* object)
 	}
 }
 
-void
+gboolean
 j_object_create(JObject* object, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1037,10 +1037,10 @@ j_object_create(JObject* object, JBatch* batch)
 	operation->exec_func = j_object_create_exec;
 	operation->free_func = j_object_create_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_object_delete(JObject* object, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1055,10 +1055,10 @@ j_object_delete(JObject* object, JBatch* batch)
 	operation->exec_func = j_object_delete_exec;
 	operation->free_func = j_object_delete_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_object_read(JObject* object, gpointer data, guint64 length, guint64 offset, guint64* bytes_read, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1066,6 +1066,7 @@ j_object_read(JObject* object, gpointer data, guint64 length, guint64 offset, gu
 	JObjectOperation* iop;
 	JOperation* operation;
 	guint64 max_operation_size;
+	gboolean ret = TRUE;
 
 	g_return_if_fail(object != NULL);
 	g_return_if_fail(data != NULL);
@@ -1094,7 +1095,7 @@ j_object_read(JObject* object, gpointer data, guint64 length, guint64 offset, gu
 		operation->exec_func = j_object_read_exec;
 		operation->free_func = j_object_read_free;
 
-		j_batch_add(batch, operation);
+		ret &= j_batch_add(batch, operation);
 
 		data = (gchar*)data + chunk_size;
 		length -= chunk_size;
@@ -1102,9 +1103,11 @@ j_object_read(JObject* object, gpointer data, guint64 length, guint64 offset, gu
 	}
 
 	*bytes_read = 0;
+
+	return ret;
 }
 
-void
+gboolean
 j_object_write(JObject* object, gconstpointer data, guint64 length, guint64 offset, guint64* bytes_written, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1112,6 +1115,7 @@ j_object_write(JObject* object, gconstpointer data, guint64 length, guint64 offs
 	JObjectOperation* iop;
 	JOperation* operation;
 	guint64 max_operation_size;
+	gboolean ret = TRUE;
 
 	g_return_if_fail(object != NULL);
 	g_return_if_fail(data != NULL);
@@ -1140,7 +1144,7 @@ j_object_write(JObject* object, gconstpointer data, guint64 length, guint64 offs
 		operation->exec_func = j_object_write_exec;
 		operation->free_func = j_object_write_free;
 
-		j_batch_add(batch, operation);
+		ret &= j_batch_add(batch, operation);
 
 		data = (gchar const*)data + chunk_size;
 		length -= chunk_size;
@@ -1148,9 +1152,11 @@ j_object_write(JObject* object, gconstpointer data, guint64 length, guint64 offs
 	}
 
 	*bytes_written = 0;
+
+	return ret;
 }
 
-void
+gboolean
 j_object_status(JObject* object, gint64* modification_time, guint64* size, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1171,10 +1177,10 @@ j_object_status(JObject* object, gint64* modification_time, guint64* size, JBatc
 	operation->exec_func = j_object_status_exec;
 	operation->free_func = j_object_status_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
-void
+gboolean
 j_object_sync(JObject* object, JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -1193,7 +1199,7 @@ j_object_sync(JObject* object, JBatch* batch)
 	operation->exec_func = j_object_sync_exec;
 	operation->free_func = j_object_sync_free;
 
-	j_batch_add(batch, operation);
+	return j_batch_add(batch, operation);
 }
 
 /**

--- a/lib/object/jobject.c
+++ b/lib/object/jobject.c
@@ -1028,7 +1028,7 @@ j_object_create(JObject* object, JBatch* batch)
 
 	JOperation* operation;
 
-	g_return_if_fail(object != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
 
 	operation = j_operation_new();
 	/// \todo key = index + namespace
@@ -1047,7 +1047,7 @@ j_object_delete(JObject* object, JBatch* batch)
 
 	JOperation* operation;
 
-	g_return_if_fail(object != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
 
 	operation = j_operation_new();
 	operation->key = object;
@@ -1068,10 +1068,10 @@ j_object_read(JObject* object, gpointer data, guint64 length, guint64 offset, gu
 	guint64 max_operation_size;
 	gboolean ret = TRUE;
 
-	g_return_if_fail(object != NULL);
-	g_return_if_fail(data != NULL);
-	g_return_if_fail(length > 0);
-	g_return_if_fail(bytes_read != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
+	g_return_val_if_fail(data != NULL, FALSE);
+	g_return_val_if_fail(length > 0, FALSE);
+	g_return_val_if_fail(bytes_read != NULL, FALSE);
 
 	max_operation_size = j_configuration_get_max_operation_size(j_configuration());
 
@@ -1117,10 +1117,10 @@ j_object_write(JObject* object, gconstpointer data, guint64 length, guint64 offs
 	guint64 max_operation_size;
 	gboolean ret = TRUE;
 
-	g_return_if_fail(object != NULL);
-	g_return_if_fail(data != NULL);
-	g_return_if_fail(length > 0);
-	g_return_if_fail(bytes_written != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
+	g_return_val_if_fail(data != NULL, FALSE);
+	g_return_val_if_fail(length > 0, FALSE);
+	g_return_val_if_fail(bytes_written != NULL, FALSE);
 
 	max_operation_size = j_configuration_get_max_operation_size(j_configuration());
 
@@ -1164,7 +1164,7 @@ j_object_status(JObject* object, gint64* modification_time, guint64* size, JBatc
 	JObjectOperation* iop;
 	JOperation* operation;
 
-	g_return_if_fail(object != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
 
 	iop = g_slice_new(JObjectOperation);
 	iop->status.object = j_object_ref(object);
@@ -1188,7 +1188,7 @@ j_object_sync(JObject* object, JBatch* batch)
 	JObjectOperation* iop;
 	JOperation* operation;
 
-	g_return_if_fail(object != NULL);
+	g_return_val_if_fail(object != NULL, FALSE);
 
 	iop = g_slice_new(JObjectOperation);
 	iop->sync.object = j_object_ref(object);

--- a/test/core/batch.c
+++ b/test/core/batch.c
@@ -57,8 +57,11 @@ test_batch_semantics(void)
 	J_TEST_TRAP_START;
 	batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT);
 
-	g_assert_true(j_batch_get_semantics(batch) != NULL);
+	semantics = j_batch_get_semantics(batch);
 
+	g_assert_true(semantics != NULL);
+
+	j_semantics_unref(semantics);
 	j_batch_unref(batch);
 
 	semantics = j_semantics_new(J_SEMANTICS_TEMPLATE_DEFAULT);
@@ -86,39 +89,46 @@ test_batch_execute_empty(void)
 }
 
 static void
-_test_batch_execute(gboolean async)
+_test_batch_execute(gboolean async, gboolean batch_less)
 {
 	g_autoptr(JCollection) collection = NULL;
 	g_autoptr(JItem) item = NULL;
 	g_autoptr(JBatch) batch = NULL;
-	gboolean ret;
+	gboolean ret = TRUE;
 
 	if (async)
 	{
 		g_atomic_int_set(&test_batch_flag, 0);
 	}
 
-	batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT);
+	if (batch_less)
+	{
+		batch = J_SINGLE_OP;
+	}
+	else
+	{
+		batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT);
+	}
 
 	collection = j_collection_create("test", batch);
+	g_assert_nonnull(collection);
 	item = j_item_create(collection, "item", NULL, batch);
-	j_item_delete(item, batch);
-	j_collection_delete(collection, batch);
+	g_assert_nonnull(item);
+	ret = j_item_delete(item, batch);
+	g_assert_true(ret);
+	ret = j_collection_delete(collection, batch);
+	g_assert_true(ret);
 
 	if (async)
 	{
 		j_batch_execute_async(batch, on_operation_completed, NULL);
+		j_batch_wait(batch);
+		g_assert_cmpint(g_atomic_int_get(&test_batch_flag), ==, 1);
 	}
-	else
+	else if (!batch_less)
 	{
 		ret = j_batch_execute(batch);
 		g_assert_true(ret);
-	}
-
-	if (async)
-	{
-		j_batch_wait(batch);
-		g_assert_cmpint(g_atomic_int_get(&test_batch_flag), ==, 1);
 	}
 }
 
@@ -126,7 +136,7 @@ static void
 test_batch_execute(void)
 {
 	J_TEST_TRAP_START;
-	_test_batch_execute(FALSE);
+	_test_batch_execute(FALSE, FALSE);
 	J_TEST_TRAP_END;
 }
 
@@ -134,7 +144,15 @@ static void
 test_batch_execute_async(void)
 {
 	J_TEST_TRAP_START;
-	_test_batch_execute(TRUE);
+	_test_batch_execute(TRUE, FALSE);
+	J_TEST_TRAP_END;
+}
+
+static void
+test_batch_execute_batch_less(void)
+{
+	J_TEST_TRAP_START;
+	_test_batch_execute(FALSE, TRUE);
 	J_TEST_TRAP_END;
 }
 
@@ -146,4 +164,5 @@ test_core_batch(void)
 	g_test_add_func("/core/batch/execute_empty", test_batch_execute_empty);
 	g_test_add_func("/core/batch/execute", test_batch_execute);
 	g_test_add_func("/core/batch/execute_async", test_batch_execute_async);
+	g_test_add_func("/core/batch/execute_batch_less", test_batch_execute_batch_less);
 }


### PR DESCRIPTION
It is now possible to pass `J_SINGLE_OP` to operations instead of a batch. The operation will then be directly executed using default semantics.